### PR TITLE
feat(auth)!: restore API key authentication alongside OAuth 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitbucket-cli"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitbucket-cli"
-version = "0.3.11"
+version = "0.3.12"
 edition = "2024"
 rust-version = "1.85"
 description = "A powerful command-line interface for Bitbucket Cloud - manage repos, PRs, issues, and pipelines from your terminal with OAuth 2.0"

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -98,10 +98,10 @@ fn create_sample_repository() -> Repository {
         uuid: "{12345678-1234-1234-1234-123456789abc}".to_string(),
         name: "my-repo".to_string(),
         full_name: "workspace/my-repo".to_string(),
-        slug: "my-repo".to_string(),
+        slug: Some("my-repo".to_string()),
         description: Some("A sample repository".to_string()),
-        is_private: true,
-        scm: "git".to_string(),
+        is_private: Some(true),
+        scm: Some("git".to_string()),
         owner: None,
         workspace: None,
         project: None,
@@ -117,6 +117,7 @@ fn create_sample_repository() -> Repository {
             branch_type: Some("branch".to_string()),
         }),
         links: None,
+        repo_type: Some("repository".to_string()),
     }
 }
 
@@ -321,10 +322,10 @@ fn bench_payload_sizes(c: &mut Criterion) {
                 uuid: format!("{{uuid-{}}}", i),
                 name: format!("repo-{}", i),
                 full_name: format!("workspace/repo-{}", i),
-                slug: format!("repo-{}", i),
+                slug: Some(format!("repo-{}", i)),
                 description: Some(format!("Description for repo {}", i)),
-                is_private: i % 2 == 0,
-                scm: "git".to_string(),
+                is_private: Some(i % 2 == 0),
+                scm: Some("git".to_string()),
                 owner: None,
                 workspace: None,
                 project: None,
@@ -337,6 +338,7 @@ fn bench_payload_sizes(c: &mut Criterion) {
                 fork_policy: None,
                 mainbranch: None,
                 links: None,
+                repo_type: Some("repository".to_string()),
             })
             .collect();
 

--- a/src/auth/api_key.rs
+++ b/src/auth/api_key.rs
@@ -1,0 +1,117 @@
+use anyhow::{Context, Result};
+use dialoguer::{Input, Password};
+
+use super::{AuthManager, Credential};
+
+/// API key authentication flow (fallback method)
+/// Note: Atlassian has deprecated app passwords in favor of OAuth2
+pub struct ApiKeyAuth;
+
+impl ApiKeyAuth {
+    /// Run the interactive API key authentication flow
+    pub async fn authenticate(auth_manager: &AuthManager) -> Result<Credential> {
+        println!("\n🔐 Bitbucket API Key Authentication");
+        println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+        println!();
+        println!("⚠️  Note: OAuth 2.0 is the preferred authentication method.");
+        println!("   API keys are provided for automation/CI scenarios.");
+        println!();
+        println!("To create an API key (HTTP access token):");
+        println!("1. Go to Bitbucket Settings → Personal settings");
+        println!("2. Click 'HTTP access tokens' under 'Access management'");
+        println!("3. Click 'Create token'");
+        println!("4. Give it a label and select required permissions");
+        println!();
+
+        let username: String = Input::new()
+            .with_prompt("Bitbucket username")
+            .interact_text()
+            .context("Failed to read username")?;
+
+        let api_key: String = Password::new()
+            .with_prompt("API key (HTTP access token)")
+            .interact()
+            .context("Failed to read API key")?;
+
+        // Trim whitespace from token (common copy-paste issue)
+        let api_key = api_key.trim().to_string();
+
+        // Validate token format
+        if api_key.is_empty() {
+            anyhow::bail!("API key cannot be empty");
+        }
+
+        // Check for common Atlassian token prefixes
+        if !api_key.starts_with("ATATT") && !api_key.starts_with("ATCTT") {
+            println!("⚠️  Warning: Token doesn't start with expected prefix (ATATT or ATCTT)");
+            println!("   This might not be a valid Bitbucket API token.");
+            println!(
+                "   Token starts with: {}",
+                &api_key.chars().take(5).collect::<String>()
+            );
+        }
+
+        let credential = Credential::ApiKey {
+            username: username.clone(),
+            api_key,
+        };
+
+        // Validate credentials by making a test API call
+        Self::validate_credentials(&credential).await?;
+
+        // Store credentials
+        auth_manager.store_credentials(&credential)?;
+
+        println!("\n✅ Successfully authenticated as {}", username);
+        println!("💡 Tip: Use 'bitbucket auth login --oauth' for a better experience");
+
+        Ok(credential)
+    }
+
+    /// Validate credentials against the Bitbucket API
+    async fn validate_credentials(credential: &Credential) -> Result<()> {
+        let client = reqwest::Client::new();
+
+        println!("🔍 Validating credentials with Bitbucket API...");
+
+        let response = client
+            .get("https://api.bitbucket.org/2.0/user")
+            .header("Authorization", credential.auth_header())
+            .header("User-Agent", "bitbucket-cli/0.3.0")
+            .send()
+            .await
+            .context("Failed to connect to Bitbucket API")?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            Ok(())
+        } else if status == reqwest::StatusCode::UNAUTHORIZED {
+            anyhow::bail!(
+                "Authentication failed (401 Unauthorized).\n\n\
+                Possible causes:\n\
+                - Incorrect username\n\
+                - Invalid or expired API token\n\
+                - Token doesn't have required permissions\n\n\
+                Please verify:\n\
+                1. Your Bitbucket username is correct\n\
+                2. Your API token is copied completely (should start with 'ATATT' or 'ATCTT')\n\
+                3. Token has 'Read' permission at minimum"
+            )
+        } else {
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| String::from("<unable to read response>"));
+            anyhow::bail!(
+                "API error ({}):\n{}\n\n\
+                This might indicate:\n\
+                - Network connectivity issues\n\
+                - Bitbucket API is unavailable\n\
+                - Rate limiting",
+                status,
+                body
+            )
+        }
+    }
+}

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,17 +1,21 @@
+pub mod api_key;
 pub mod file_store;
 pub mod keyring_store;
 pub mod oauth;
 
 use anyhow::Result;
+use base64::Engine;
 use serde::{Deserialize, Serialize};
 
+pub use api_key::*;
 pub use file_store::*;
 pub use keyring_store::*;
 pub use oauth::*;
 
-/// OAuth 2.0 credential
+/// Credential types for Bitbucket authentication
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Credential {
+    /// OAuth 2.0 credentials (preferred method)
     OAuth {
         access_token: String,
         refresh_token: Option<String>,
@@ -21,6 +25,8 @@ pub enum Credential {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         client_secret: Option<String>,
     },
+    /// API Key / HTTP Access Token (for automation/CI)
+    ApiKey { username: String, api_key: String },
 }
 
 impl Credential {
@@ -34,13 +40,24 @@ impl Credential {
                 result.push_str(access_token);
                 result
             }
+            Credential::ApiKey { username, api_key } => {
+                let basic = format!("{}:{}", username, api_key);
+                let encoded = base64::engine::general_purpose::STANDARD.encode(basic.as_bytes());
+                let mut result = String::with_capacity(6 + encoded.len());
+                result.push_str("Basic ");
+                result.push_str(&encoded);
+                result
+            }
         }
     }
 
     /// Get the credential type name for display
     #[inline]
     pub fn type_name(&self) -> &'static str {
-        "OAuth 2.0"
+        match self {
+            Credential::OAuth { .. } => "OAuth 2.0",
+            Credential::ApiKey { .. } => "API Key",
+        }
     }
 
     /// Check if the credential needs refresh
@@ -66,6 +83,14 @@ impl Credential {
                 client_secret: Some(secret),
                 ..
             } => Some((id, secret)),
+            _ => None,
+        }
+    }
+
+    /// Get username (only available for API key credentials)
+    pub fn username(&self) -> Option<&str> {
+        match self {
+            Credential::ApiKey { username, .. } => Some(username),
             _ => None,
         }
     }

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -3,18 +3,22 @@ use clap::Subcommand;
 use colored::Colorize;
 use dialoguer::Input;
 
-use crate::auth::{AuthManager, OAuthFlow};
+use crate::auth::{ApiKeyAuth, AuthManager, OAuthFlow};
 use crate::config::Config;
 
 #[derive(Subcommand)]
 pub enum AuthCommands {
-    /// Authenticate with Bitbucket via OAuth 2.0
+    /// Authenticate with Bitbucket (OAuth 2.0 or API key)
     Login {
-        /// OAuth Client ID
+        /// Use API key authentication (for automation/CI)
+        #[arg(long)]
+        api_key: bool,
+
+        /// OAuth Client ID (for OAuth authentication)
         #[arg(long, env = "BITBUCKET_CLIENT_ID")]
         client_id: Option<String>,
 
-        /// OAuth Client Secret
+        /// OAuth Client Secret (for OAuth authentication)
         #[arg(long, env = "BITBUCKET_CLIENT_SECRET")]
         client_secret: Option<String>,
     },
@@ -30,11 +34,19 @@ impl AuthCommands {
     pub async fn run(self) -> Result<()> {
         match self {
             AuthCommands::Login {
+                api_key,
                 client_id,
                 client_secret,
             } => {
                 let auth_manager = AuthManager::new()?;
 
+                // If --api-key flag is set, use API key authentication
+                if api_key {
+                    ApiKeyAuth::authenticate(&auth_manager).await?;
+                    return Ok(());
+                }
+
+                // Otherwise, use OAuth 2.0 authentication
                 // Resolve consumer credentials from (in priority):
                 // 1. CLI flags / env vars
                 // 2. Previously stored credentials
@@ -110,9 +122,18 @@ impl AuthCommands {
                 let config = Config::load()?;
 
                 if auth_manager.is_authenticated() {
-                    println!("{} Authenticated via OAuth 2.0", "✓".green());
+                    println!("{} Authenticated", "✓".green());
 
                     if let Ok(Some(credential)) = auth_manager.get_credentials() {
+                        println!("  {} {}", "Method:".dimmed(), credential.type_name());
+
+                        // Show username from credential for API keys, or config for OAuth
+                        if let Some(username) = credential.username() {
+                            println!("  {} {}", "Username:".dimmed(), username);
+                        } else if let Some(username) = config.username() {
+                            println!("  {} {}", "Username:".dimmed(), username);
+                        }
+
                         if credential.needs_refresh() {
                             println!(
                                 "  {} {}",
@@ -120,10 +141,6 @@ impl AuthCommands {
                                 "Token needs refresh (will auto-refresh on next use)".yellow()
                             );
                         }
-                    }
-
-                    if let Some(username) = config.username() {
-                        println!("  {} {}", "Username:".dimmed(), username);
                     }
 
                     if let Some(workspace) = config.default_workspace() {

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -51,14 +51,10 @@ impl AuthCommands {
                 // 1. CLI flags / env vars
                 // 2. Previously stored credentials
                 // 3. Interactive prompt (first-time only)
-                let stored_consumer = auth_manager
-                    .get_credentials()
-                    .ok()
-                    .flatten()
-                    .and_then(|c| {
-                        c.oauth_consumer_credentials()
-                            .map(|(id, secret)| (id.to_owned(), secret.to_owned()))
-                    });
+                let stored_consumer = auth_manager.get_credentials().ok().flatten().and_then(|c| {
+                    c.oauth_consumer_credentials()
+                        .map(|(id, secret)| (id.to_owned(), secret.to_owned()))
+                });
 
                 let client_id = client_id
                     .or_else(|| stored_consumer.as_ref().map(|(id, _)| id.clone()))

--- a/src/cli/pr.rs
+++ b/src/cli/pr.rs
@@ -508,9 +508,7 @@ impl PrCommands {
                 let (workspace, repo_slug) = parse_repo(&repo)?;
                 let client = BitbucketClient::from_stored().await?;
 
-                let comments = client
-                    .list_pr_comments(&workspace, &repo_slug, id)
-                    .await?;
+                let comments = client.list_pr_comments(&workspace, &repo_slug, id).await?;
 
                 let mut values: Vec<_> = comments.values.into_iter().take(limit as usize).collect();
 
@@ -554,12 +552,7 @@ impl PrCommands {
                     .get_pr_comment(&workspace, &repo_slug, id, comment_id)
                     .await?;
 
-                println!(
-                    "{} #{} on PR #{}",
-                    "Comment".bold(),
-                    comment.id,
-                    id
-                );
+                println!("{} #{} on PR #{}", "Comment".bold(), comment.id, id);
                 println!("{}", "─".repeat(60));
 
                 println!("{} {}", "Author:".dimmed(), comment.user.display_name);
@@ -583,10 +576,10 @@ impl PrCommands {
                         Some(l) => format!("{}:{}", inline.path, l),
                         None => inline.path.clone(),
                     };
-                    println!("{} {}", "Type:".dimmed(), "inline");
+                    println!("{} inline", "Type:".dimmed());
                     println!("{} {}", "File:".dimmed(), location.cyan());
                 } else {
-                    println!("{} {}", "Type:".dimmed(), "general");
+                    println!("{} general", "Type:".dimmed());
                 }
 
                 println!();


### PR DESCRIPTION
## Summary
- Restores API key authentication removed in v0.3.10 (fixes #45)
- Keeps OAuth 2.0 as default, adds `--api-key` flag for API key auth
- Both methods now coexist: OAuth for interactive use, API keys for automation/CI

## Changes
- ✅ Restored `src/auth/api_key.rs` module with validation
- ✅ Added `Credential::ApiKey` variant with username/api_key fields
- ✅ Implemented HTTP Basic auth for API keys
- ✅ Added `--api-key` flag to `bitbucket auth login`
- ✅ Updated `auth status` to show credential type
- ✅ All tests pass, clippy clean

## Usage
```bash
# OAuth 2.0 (default, recommended)
bitbucket auth login

# API key / HTTP access token (for CI/automation)
bitbucket auth login --api-key
```

## Breaking Change
Users with v0.3.9 stored API keys must re-authenticate with `bitbucket auth login --api-key` due to credential format change. OAuth users unaffected.

## Test Plan
- [x] Build succeeds
- [x] All unit tests pass  
- [x] Clippy passes
- [x] Help text shows `--api-key` flag
- [ ] Manual test: API key authentication flow
- [ ] Manual test: API key stored credentials load correctly
- [ ] Manual test: `auth status` shows "API Key" method

Closes #45