### PR TITLE
feat(repo): add --fork-policy flag to repo create command

### DIFF
--- a/src/cli/repo.rs
+++ b/src/cli/repo.rs
@@ -57,6 +57,10 @@ pub enum RepoCommands {
         /// Project key to add repository to
         #[arg(short, long)]
         project: Option<String>,
+
+        /// Fork policy: allow_forks, no_public_forks, no_forks (default: allow_forks when --public, no_public_forks otherwise)
+        #[arg(long)]
+        fork_policy: Option<String>,
     },
 
     /// Fork a repository
@@ -264,10 +268,19 @@ impl RepoCommands {
                 description,
                 public,
                 project,
+                fork_policy,
             } => {
                 let client = BitbucketClient::from_stored().await?;
 
                 let slug = name.to_lowercase().replace(' ', "-");
+
+                let resolved_fork_policy = fork_policy.unwrap_or_else(|| {
+                    if public {
+                        "allow_forks".to_string()
+                    } else {
+                        "no_public_forks".to_string()
+                    }
+                });
 
                 let request = CreateRepositoryRequest {
                     scm: "git".to_string(),
@@ -275,6 +288,7 @@ impl RepoCommands {
                     description,
                     is_private: Some(!public),
                     project: project.map(|key| crate::models::ProjectKey { key }),
+                    fork_policy: Some(resolved_fork_policy),
                     ..Default::default()
                 };
 

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -38,14 +38,10 @@ impl EventHandler {
                         Ok(event::Event::Key(key)) if tx.send(Event::Key(key)).is_err() => {
                             break;
                         }
-                        Ok(event::Event::Mouse(mouse))
-                            if tx.send(Event::Mouse(mouse)).is_err() =>
-                        {
+                        Ok(event::Event::Mouse(mouse)) if tx.send(Event::Mouse(mouse)).is_err() => {
                             break;
                         }
-                        Ok(event::Event::Resize(w, h))
-                            if tx.send(Event::Resize(w, h)).is_err() =>
-                        {
+                        Ok(event::Event::Resize(w, h)) if tx.send(Event::Resize(w, h)).is_err() => {
                             break;
                         }
                         Ok(_) => {}

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -35,21 +35,20 @@ impl EventHandler {
                 // Poll for events with timeout
                 if event::poll(tick_rate).unwrap_or(false) {
                     match event::read() {
-                        Ok(event::Event::Key(key)) => {
-                            if tx.send(Event::Key(key)).is_err() {
-                                break;
-                            }
+                        Ok(event::Event::Key(key)) if tx.send(Event::Key(key)).is_err() => {
+                            break;
                         }
-                        Ok(event::Event::Mouse(mouse)) => {
-                            if tx.send(Event::Mouse(mouse)).is_err() {
-                                break;
-                            }
+                        Ok(event::Event::Mouse(mouse))
+                            if tx.send(Event::Mouse(mouse)).is_err() =>
+                        {
+                            break;
                         }
-                        Ok(event::Event::Resize(w, h)) => {
-                            if tx.send(Event::Resize(w, h)).is_err() {
-                                break;
-                            }
+                        Ok(event::Event::Resize(w, h))
+                            if tx.send(Event::Resize(w, h)).is_err() =>
+                        {
+                            break;
                         }
+                        Ok(_) => {}
                         _ => {}
                     }
                 } else {


### PR DESCRIPTION
## Summary

- Add `--fork-policy` flag to `repo create` accepting `allow_forks`, `no_public_forks`, or `no_forks`
- When `--public` is passed without `--fork-policy`, default to `allow_forks` (Bitbucket requires this for public repos)
- When `--public` is not passed, default to `no_public_forks` (preserves existing behaviour)

## Test Plan

- [ ] `bitbucket repo create <workspace> <name> --public` no longer returns `Public repositories must allow public forks` error
- [ ] `bitbucket repo create <workspace> <name> --public --fork-policy no_forks` passes the explicit policy through
- [ ] `bitbucket repo create <workspace> <name>` (private, no flag) still uses `no_public_forks` as before