### PR TITLE
feat(pr): list pipelines for a PR's head commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 Cargo.lock
 !Cargo.lock
 
+# Git worktrees
+.worktrees/
+
 # IDE
 .idea/
 .vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitbucket-cli"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitbucket-cli"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2024"
 rust-version = "1.85"
 description = "A powerful command-line interface for Bitbucket Cloud - manage repos, PRs, issues, and pipelines from your terminal with OAuth 2.0"

--- a/src/api/pipelines.rs
+++ b/src/api/pipelines.rs
@@ -124,6 +124,39 @@ impl BitbucketClient {
         }
     }
 
+    /// List pipelines whose target commit matches `commit_hash`, newest first.
+    ///
+    /// Bitbucket's pipelines endpoint does not expose a server-side filter on
+    /// `target.commit.hash` (both the `?target.commit.hash=` query param and
+    /// the BBQL `q=` filter are silently ignored as of the 2.0 API), so this
+    /// fetches the most recent pipelines and filters client-side. `scan_limit`
+    /// bounds how many of the repo's recent pipelines are scanned and is
+    /// capped at Bitbucket's pagelen ceiling of 100; on repos that churn more
+    /// than 100 pipelines between the commit landing and this call, matches
+    /// older than that window will be missed.
+    pub async fn list_pipelines_for_commit(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        commit_hash: &str,
+        scan_limit: u32,
+    ) -> Result<Vec<Pipeline>> {
+        let pagelen = scan_limit.clamp(1, 100);
+        let pipelines = self
+            .list_pipelines(workspace, repo_slug, None, Some(pagelen))
+            .await?;
+        Ok(pipelines
+            .values
+            .into_iter()
+            .filter(|p| {
+                p.target
+                    .commit
+                    .as_ref()
+                    .is_some_and(|c| commit_hashes_match(&c.hash, commit_hash))
+            })
+            .collect())
+    }
+
     /// Get pipeline by build number
     pub async fn get_pipeline_by_build_number(
         &self,
@@ -141,5 +174,55 @@ impl BitbucketClient {
             .into_iter()
             .find(|p| p.build_number == build_number)
             .ok_or_else(|| anyhow::anyhow!("Pipeline #{} not found", build_number))
+    }
+}
+
+/// Compare two git commit hashes that may differ in length.
+///
+/// Bitbucket's pull-request API returns a 12-char short hash while the
+/// pipelines API returns the full 40-char hash. Match by treating the
+/// shorter of the two as a prefix of the longer.
+fn commit_hashes_match(a: &str, b: &str) -> bool {
+    let (long, short) = if a.len() >= b.len() { (a, b) } else { (b, a) };
+    !short.is_empty() && long.starts_with(short)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::commit_hashes_match;
+
+    #[test]
+    fn exact_equality_matches() {
+        assert!(commit_hashes_match("abc123", "abc123"));
+    }
+
+    #[test]
+    fn short_pr_hash_matches_full_pipeline_hash() {
+        assert!(commit_hashes_match(
+            "975f24a99dab12345abc678def910ghi112233jk",
+            "975f24a99dab"
+        ));
+    }
+
+    #[test]
+    fn full_pr_hash_matches_short_pipeline_hash() {
+        assert!(commit_hashes_match(
+            "975f24a99dab",
+            "975f24a99dab12345abc678def910ghi112233jk"
+        ));
+    }
+
+    #[test]
+    fn different_commits_do_not_match() {
+        assert!(!commit_hashes_match("abc123def", "abc999def"));
+    }
+
+    #[test]
+    fn empty_hash_never_matches() {
+        // Guard against false positives if the API returns a missing hash
+        // that somehow deserializes to an empty string.
+        assert!(!commit_hashes_match("", "abc123"));
+        assert!(!commit_hashes_match("abc123", ""));
+        assert!(!commit_hashes_match("", ""));
     }
 }

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -358,7 +358,7 @@ fn parse_repo(repo: &str) -> Result<(String, String)> {
     Ok((parts[0].to_string(), parts[1].to_string()))
 }
 
-fn format_status(state: &PipelineStateName, result: Option<&PipelineResultName>) -> String {
+pub(crate) fn format_status(state: &PipelineStateName, result: Option<&PipelineResultName>) -> String {
     match state {
         PipelineStateName::Pending => "PENDING".yellow().to_string(),
         PipelineStateName::InProgress => "RUNNING".blue().to_string(),
@@ -380,7 +380,7 @@ fn format_status(state: &PipelineStateName, result: Option<&PipelineResultName>)
     }
 }
 
-fn format_duration(seconds: u64) -> String {
+pub(crate) fn format_duration(seconds: u64) -> String {
     if seconds < 60 {
         format!("{}s", seconds)
     } else if seconds < 3600 {

--- a/src/cli/pr.rs
+++ b/src/cli/pr.rs
@@ -159,6 +159,19 @@ pub enum PrCommands {
         /// Comment ID
         comment_id: u64,
     },
+
+    /// List pipelines for the PR's head commit
+    Pipelines {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        id: u64,
+
+        /// Maximum recent pipelines to scan for matches (capped at 100)
+        #[arg(short, long, default_value = "100")]
+        scan_limit: u32,
+    },
 }
 
 #[derive(ValueEnum, Clone)]
@@ -209,6 +222,22 @@ struct PrRow {
     state: String,
     #[tabled(rename = "UPDATED")]
     updated: String,
+}
+
+#[derive(Tabled)]
+struct PipelineRow {
+    #[tabled(rename = "#")]
+    build: u64,
+    #[tabled(rename = "STATUS")]
+    status: String,
+    #[tabled(rename = "BRANCH")]
+    branch: String,
+    #[tabled(rename = "COMMIT")]
+    commit: String,
+    #[tabled(rename = "TRIGGERED")]
+    triggered: String,
+    #[tabled(rename = "DURATION")]
+    duration: String,
 }
 
 #[derive(Tabled)]
@@ -536,6 +565,71 @@ impl PrCommands {
 
                 let table = Table::new(rows).to_string();
                 println!("{}", table);
+
+                Ok(())
+            }
+
+            PrCommands::Pipelines {
+                repo,
+                id,
+                scan_limit,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let pr = client.get_pull_request(&workspace, &repo_slug, id).await?;
+                let head_commit = pr
+                    .source
+                    .commit
+                    .as_ref()
+                    .map(|c| c.hash.clone())
+                    .context("PR has no head commit hash")?;
+
+                let pipelines = client
+                    .list_pipelines_for_commit(&workspace, &repo_slug, &head_commit, scan_limit)
+                    .await?;
+
+                if pipelines.is_empty() {
+                    println!(
+                        "No pipelines found for PR #{} head commit {} (scanned {} most recent).",
+                        id,
+                        head_commit.chars().take(12).collect::<String>(),
+                        scan_limit.clamp(1, 100)
+                    );
+                    return Ok(());
+                }
+
+                let rows: Vec<PipelineRow> = pipelines
+                    .iter()
+                    .map(|p| {
+                        let duration = match (p.build_seconds_used, &p.state.name) {
+                            (Some(s), _) => super::pipeline::format_duration(s),
+                            (None, crate::models::PipelineStateName::InProgress) => {
+                                "running...".to_string()
+                            }
+                            _ => "-".to_string(),
+                        };
+
+                        PipelineRow {
+                            build: p.build_number,
+                            status: super::pipeline::format_status(
+                                &p.state.name,
+                                p.state.result.as_ref().map(|r| &r.name),
+                            ),
+                            branch: p.target.ref_name.clone().unwrap_or_else(|| "-".to_string()),
+                            commit: p
+                                .target
+                                .commit
+                                .as_ref()
+                                .map(|c| c.hash.chars().take(12).collect())
+                                .unwrap_or_else(|| "-".to_string()),
+                            triggered: p.created_on.format("%Y-%m-%d %H:%M").to_string(),
+                            duration,
+                        }
+                    })
+                    .collect();
+
+                println!("{}", Table::new(rows));
 
                 Ok(())
             }


### PR DESCRIPTION
## Summary

Adds `bitbucket pr pipelines <repo> <id>` so the CI state of a PR can be looked up from this CLI without dropping to curl. The existing `pipeline list` lists every recent pipeline on the repo and has no way to scope to a PR; that gap meant any "is this PR green" check required hand-rolling against `/2.0/repositories/.../pipelines/`.

```
$ bitbucket pr pipelines lexmata/jira-cli 3
+----+---------+-------------------------+--------------+------------------+----------+
| #  | STATUS  | BRANCH                  | COMMIT       | TRIGGERED        | DURATION |
+----+---------+-------------------------+--------------+------------------+----------+
| 17 | SUCCESS | hotfix/LX-64-search-jql | 975f24a99dab | 2026-05-19 14:06 | 3m 3s    |
+----+---------+-------------------------+--------------+------------------+----------+
```

## Implementation notes

- Bitbucket's pipelines list endpoint **does not honour** `?target.commit.hash=` nor the BBQL `q=` filter — both are silently ignored. Verified by curl against this repo. So we filter client-side after fetching the most recent N pipelines (default `--scan-limit 100`, which is also Bitbucket's pagelen ceiling). Documented in the new API method's rustdoc.
- The PR API returns 12-char short hashes while the pipelines API returns full 40-char hashes. A naive `==` compare never matches. New `commit_hashes_match` helper treats whichever side is shorter as a prefix of the longer one and is unit-tested for the four interesting cases (exact, short-vs-long, long-vs-short, mismatch, empty-string).
- `format_status` and `format_duration` in `cli/pipeline.rs` graduate to `pub(crate)` so the new pr.rs handler can reuse them rather than duplicating the status-color match arms.
- Drive-by `.gitignore`: add `.worktrees/` since I work out of git worktrees and don't want their `target/` showing in `git status`.

## Test plan

- [x] `cargo test` — 9 passing (4 pre-existing config tests + 5 new commit-hash-match tests)
- [x] `cargo clippy -- -D warnings` — clean
- [x] Live: `bitbucket pr pipelines lexmata/jira-cli 3` against a merged PR
- [x] Live: same against PR #2 (older head commit)
- [x] Live: `--help` shows the new subcommand
- [ ] CI passing (GitHub Actions)