### PR TITLE
feat(downloads): add `repo download` upload/list/delete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,6 +1610,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2256,6 +2272,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2264,6 +2281,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3042,6 +3060,12 @@ dependencies = [
  "tempfile",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ crossterm = "0.29"
 
 # Async runtime & HTTP
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "multipart"], default-features = false }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A powerful command-line interface for Bitbucket Cloud. Manage repositories, pull
 
 ## ✨ Features
 
-- 📁 **Repository Management** - List, view, clone, create, and manage repositories
+- 📁 **Repository Management** - List, view, clone, create, manage repositories, and upload/manage downloads
 - 🔀 **Pull Requests** - Create, review, merge, approve, and manage PRs
 - 🐛 **Issue Tracking** - Create, view, comment on, and manage issues
 - ⚡ **Pipelines** - Trigger, monitor, and manage CI/CD pipelines
@@ -135,6 +135,10 @@ bitbucket pr list myworkspace/myrepo
 # Create a pull request
 bitbucket pr create myworkspace/myrepo --title "My PR" --source feature-branch
 
+# Upload a file (e.g. a screenshot) to the repo downloads area, then
+# reference the printed URL from a PR description or comment as ![](url)
+bitbucket repo download upload myworkspace/myrepo screenshot.png
+
 # Launch interactive TUI
 bitbucket tui --workspace myworkspace
 ```
@@ -144,7 +148,7 @@ bitbucket tui --workspace myworkspace
 | Command | Description |
 |---------|-------------|
 | `bitbucket auth` | Manage authentication (login, logout, status) |
-| `bitbucket repo` | Manage repositories (list, view, clone, create, fork, delete) |
+| `bitbucket repo` | Manage repositories (list, view, clone, create, fork, delete, download) |
 | `bitbucket pr` | Manage pull requests (list, view, create, merge, approve, decline) |
 | `bitbucket issue` | Manage issues (list, view, create, comment, close, reopen) |
 | `bitbucket pipeline` | Manage pipelines (list, view, trigger, stop) |

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -135,6 +135,23 @@ impl BitbucketClient {
         self.handle_empty_response(response).await
     }
 
+    /// Make a multipart/form-data POST request, not expecting a JSON response body.
+    ///
+    /// Used for endpoints like repository downloads, which accept file uploads and
+    /// respond with `201 Created` and an empty body.
+    pub async fn post_multipart(&self, path: &str, form: reqwest::multipart::Form) -> Result<()> {
+        let response = self
+            .client
+            .post(self.url(path))
+            .header("Authorization", self.credential.auth_header())
+            .multipart(form)
+            .send()
+            .await
+            .context("Request failed")?;
+
+        self.handle_empty_response(response).await
+    }
+
     /// Make a PUT request with JSON body
     pub async fn put<T: DeserializeOwned, B: serde::Serialize>(
         &self,

--- a/src/api/downloads.rs
+++ b/src/api/downloads.rs
@@ -1,0 +1,127 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use reqwest::multipart::{Form, Part};
+
+use super::BitbucketClient;
+use crate::models::{Download, Paginated};
+
+impl BitbucketClient {
+    /// Upload one or more files to a repository's downloads area.
+    ///
+    /// Uploading a file whose name matches an existing artifact replaces it.
+    pub async fn upload_downloads(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        files: &[(String, PathBuf)],
+    ) -> Result<()> {
+        let mut form = Form::new();
+
+        for (upload_name, path) in files {
+            let bytes = std::fs::read(path)
+                .with_context(|| format!("Failed to read file '{}'", path.display()))?;
+            let part = Part::bytes(bytes).file_name(upload_name.clone());
+            // Bitbucket expects every file under the "files" field.
+            form = form.part("files", part);
+        }
+
+        let path = format!("/repositories/{}/{}/downloads", workspace, repo_slug);
+        self.post_multipart(&path, form).await
+    }
+
+    /// List the artifacts in a repository's downloads area.
+    pub async fn list_downloads(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+    ) -> Result<Paginated<Download>> {
+        let path = format!("/repositories/{}/{}/downloads", workspace, repo_slug);
+        self.get(&path).await
+    }
+
+    /// Delete a single artifact from a repository's downloads area.
+    pub async fn delete_download(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        filename: &str,
+    ) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/downloads/{}",
+            workspace,
+            repo_slug,
+            urlencode_segment(filename)
+        );
+        self.delete(&path).await
+    }
+}
+
+/// Build the public, browser-facing URL for a download artifact.
+///
+/// This is the URL to embed in markdown (e.g. `![alt](url)`); it is rendered
+/// for anyone with read access to the repository.
+pub fn download_url(workspace: &str, repo_slug: &str, name: &str) -> String {
+    format!(
+        "https://bitbucket.org/{}/{}/downloads/{}",
+        workspace,
+        repo_slug,
+        urlencode_segment(name)
+    )
+}
+
+/// Extract the file name (final path component) from a path, for use as the
+/// uploaded artifact name.
+pub fn upload_name_for(path: &Path) -> Result<String> {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map(|s| s.to_string())
+        .with_context(|| format!("Could not determine a file name for '{}'", path.display()))
+}
+
+/// Percent-encode the characters that are unsafe in a single URL path segment.
+/// Intentionally minimal — file names are mostly `[A-Za-z0-9._-]` plus spaces.
+fn urlencode_segment(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{:02X}", b)),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn download_url_is_browser_facing_host() {
+        assert_eq!(
+            download_url("acme", "widgets", "shot.png"),
+            "https://bitbucket.org/acme/widgets/downloads/shot.png"
+        );
+    }
+
+    #[test]
+    fn download_url_encodes_spaces_and_specials() {
+        assert_eq!(
+            download_url("acme", "widgets", "my shot (1).png"),
+            "https://bitbucket.org/acme/widgets/downloads/my%20shot%20%281%29.png"
+        );
+    }
+
+    #[test]
+    fn upload_name_takes_final_component() {
+        let p = PathBuf::from("/tmp/screenshots/login.png");
+        assert_eq!(upload_name_for(&p).unwrap(), "login.png");
+    }
+
+    #[test]
+    fn urlencode_leaves_safe_chars_untouched() {
+        assert_eq!(urlencode_segment("a-b_c.d~1.png"), "a-b_c.d~1.png");
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,7 +1,9 @@
 pub mod client;
+pub mod downloads;
 pub mod issues;
 pub mod pipelines;
 pub mod pullrequests;
 pub mod repos;
 
 pub use client::*;
+pub use downloads::{download_url, upload_name_for};

--- a/src/auth/oauth.rs
+++ b/src/auth/oauth.rs
@@ -112,6 +112,9 @@ impl OAuthFlow {
         let (auth_url, csrf_token) = client
             .authorize_url(CsrfToken::new_random)
             .add_scope(Scope::new("repository".to_string()))
+            // Required to upload repository downloads (`repo download upload`).
+            // Existing users must re-run `auth login` to consent.
+            .add_scope(Scope::new("repository:write".to_string()))
             .add_scope(Scope::new("pullrequest".to_string()))
             .add_scope(Scope::new("issue".to_string()))
             .add_scope(Scope::new("pipeline".to_string()))

--- a/src/cli/repo.rs
+++ b/src/cli/repo.rs
@@ -1,9 +1,11 @@
+use std::path::PathBuf;
+
 use anyhow::{Context, Result};
 use clap::Subcommand;
 use colored::Colorize;
 use tabled::{Table, Tabled};
 
-use crate::api::BitbucketClient;
+use crate::api::{BitbucketClient, download_url, upload_name_for};
 use crate::models::CreateRepositoryRequest;
 
 #[derive(Subcommand)]
@@ -81,6 +83,44 @@ pub enum RepoCommands {
     Delete {
         /// Repository in format workspace/repo-slug
         repo: String,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+
+    /// Manage repository downloads (uploaded file artifacts)
+    Download {
+        #[command(subcommand)]
+        command: DownloadCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum DownloadCommands {
+    /// Upload one or more files to the repository's downloads area
+    Upload {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// File(s) to upload. Uploading a file whose name already exists replaces it.
+        #[arg(required = true)]
+        files: Vec<PathBuf>,
+    },
+
+    /// List artifacts in the repository's downloads area
+    List {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+    },
+
+    /// Delete an artifact from the repository's downloads area
+    Delete {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Name of the artifact to delete
+        name: String,
 
         /// Skip confirmation prompt
         #[arg(short, long)]
@@ -359,7 +399,121 @@ impl RepoCommands {
 
                 Ok(())
             }
+
+            RepoCommands::Download { command } => command.run().await,
         }
+    }
+}
+
+#[derive(Tabled)]
+struct DownloadRow {
+    #[tabled(rename = "NAME")]
+    name: String,
+    #[tabled(rename = "SIZE")]
+    size: String,
+    #[tabled(rename = "DOWNLOADS")]
+    downloads: String,
+}
+
+impl DownloadCommands {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            DownloadCommands::Upload { repo, files } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                // Resolve each path to (upload-name, path) up front so a bad path
+                // fails before we open a network connection.
+                let uploads: Vec<(String, PathBuf)> = files
+                    .iter()
+                    .map(|p| Ok((upload_name_for(p)?, p.clone())))
+                    .collect::<Result<_>>()?;
+
+                let client = BitbucketClient::from_stored().await?;
+                client
+                    .upload_downloads(&workspace, &repo_slug, &uploads)
+                    .await?;
+
+                for (name, _) in &uploads {
+                    println!(
+                        "{} Uploaded {}",
+                        "✓".green(),
+                        download_url(&workspace, &repo_slug, name).cyan()
+                    );
+                }
+
+                Ok(())
+            }
+
+            DownloadCommands::List { repo } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let downloads = client.list_downloads(&workspace, &repo_slug).await?;
+
+                if downloads.values.is_empty() {
+                    println!("No downloads found in {}", repo);
+                    return Ok(());
+                }
+
+                let rows: Vec<DownloadRow> = downloads
+                    .values
+                    .iter()
+                    .map(|d| DownloadRow {
+                        name: d.name.clone(),
+                        size: d.size.map(format_size).unwrap_or_else(|| "-".to_string()),
+                        downloads: d
+                            .downloads
+                            .map(|n| n.to_string())
+                            .unwrap_or_else(|| "-".to_string()),
+                    })
+                    .collect();
+
+                println!("{}", Table::new(rows));
+
+                Ok(())
+            }
+
+            DownloadCommands::Delete { repo, name, yes } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                if !yes {
+                    use dialoguer::Confirm;
+                    let confirmed = Confirm::new()
+                        .with_prompt(format!("Delete download {} from {}?", name.red(), repo))
+                        .default(false)
+                        .interact()?;
+
+                    if !confirmed {
+                        println!("Aborted");
+                        return Ok(());
+                    }
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                client
+                    .delete_download(&workspace, &repo_slug, &name)
+                    .await?;
+
+                println!("{} Deleted download {}", "✓".green(), name);
+
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Format a byte count into a short human-readable string.
+fn format_size(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    let mut size = bytes as f64;
+    let mut unit = 0;
+    while size >= 1024.0 && unit < UNITS.len() - 1 {
+        size /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{} {}", bytes, UNITS[unit])
+    } else {
+        format!("{:.1} {}", size, UNITS[unit])
     }
 }
 
@@ -372,4 +526,37 @@ fn parse_repo(repo: &str) -> Result<(String, String)> {
         );
     }
     Ok((parts[0].to_string(), parts[1].to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_repo_splits_workspace_and_slug() {
+        let (ws, slug) = parse_repo("acme/widgets").unwrap();
+        assert_eq!(ws, "acme");
+        assert_eq!(slug, "widgets");
+    }
+
+    #[test]
+    fn parse_repo_rejects_missing_slug() {
+        assert!(parse_repo("acme").is_err());
+        assert!(parse_repo("acme/widgets/extra").is_err());
+    }
+
+    #[test]
+    fn format_size_uses_bytes_below_1k() {
+        assert_eq!(format_size(0), "0 B");
+        assert_eq!(format_size(512), "512 B");
+        assert_eq!(format_size(1023), "1023 B");
+    }
+
+    #[test]
+    fn format_size_scales_to_larger_units() {
+        assert_eq!(format_size(1024), "1.0 KB");
+        assert_eq!(format_size(1536), "1.5 KB");
+        assert_eq!(format_size(1024 * 1024), "1.0 MB");
+        assert_eq!(format_size(5 * 1024 * 1024 * 1024), "5.0 GB");
+    }
 }

--- a/src/models/repo.rs
+++ b/src/models/repo.rs
@@ -59,6 +59,22 @@ pub struct Branch {
     pub branch_type: Option<String>,
 }
 
+/// A repository download artifact (the "Downloads" area of a repo).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Download {
+    pub name: String,
+    pub size: Option<u64>,
+    /// Number of times this artifact has been downloaded.
+    pub downloads: Option<u64>,
+    pub links: Option<DownloadLinks>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DownloadLinks {
+    #[serde(rename = "self")]
+    pub self_link: Option<Link>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Project {
     pub uuid: String,


### PR DESCRIPTION
Bitbucket Cloud's PR comment/description fields only accept markdown text, so embedding a screenshot in a PR requires first hosting the image somewhere with a stable URL. The repository Downloads area is the natural in-Bitbucket host, but the CLI had no way to reach it. Workflow: upload the file to get a URL, then reference it in any markdown field (PR description, comment, wiki, ...).

- api: add post_multipart() to the client; new downloads module with upload_downloads/list_downloads/delete_download plus pure helpers (download_url, upload_name_for, URL-segment encoder).
- models: add Download/DownloadLinks.
- cli: add `repo download {upload,list,delete}`.
- auth: request the repository:write OAuth scope, required to upload downloads. Existing OAuth users must re-run `auth login` to consent.
- docs: document `repo download` in the README (features, quick start, commands).
- enable reqwest "multipart" feature.

Unit tests cover the pure helpers (URL building, name handling, size formatting, repo parsing). Network paths follow the repo's existing no-mock convention.

## Type of Change

<!-- Please check the relevant option. -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] 🧪 Test updates

