### PR TITLE
feat(pr): add `pr edit` command to edit title/description

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ bitbucket pr list myworkspace/myrepo
 # Create a pull request
 bitbucket pr create myworkspace/myrepo --title "My PR" --source feature-branch
 
+# Edit a pull request's description ($EDITOR opens prefilled with the current text)
+bitbucket pr edit myworkspace/myrepo 42
+
 # Upload a file (e.g. a screenshot) to the repo downloads area, then
 # reference the printed URL from a PR description or comment as ![](url)
 bitbucket repo download upload myworkspace/myrepo screenshot.png
@@ -149,7 +152,7 @@ bitbucket tui --workspace myworkspace
 |---------|-------------|
 | `bitbucket auth` | Manage authentication (login, logout, status) |
 | `bitbucket repo` | Manage repositories (list, view, clone, create, fork, delete, download) |
-| `bitbucket pr` | Manage pull requests (list, view, create, merge, approve, decline) |
+| `bitbucket pr` | Manage pull requests (list, view, create, edit, merge, approve, decline) |
 | `bitbucket issue` | Manage issues (list, view, create, comment, close, reopen) |
 | `bitbucket pipeline` | Manage pipelines (list, view, trigger, stop) |
 | `bitbucket tui` | Launch interactive terminal UI |

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -47,6 +47,9 @@ bitbucket pr list myworkspace/myrepo
 # Create a pull request
 bitbucket pr create myworkspace/myrepo --title "My PR" --source feature-branch
 
+# Edit a pull request description (opens $EDITOR; --body/--title for non-interactive)
+bitbucket pr edit myworkspace/myrepo 42
+
 # Launch interactive TUI
 bitbucket tui --workspace myworkspace
 ```

--- a/docs/src/app/pages/commands/pr/pr.component.ts
+++ b/docs/src/app/pages/commands/pr/pr.component.ts
@@ -98,6 +98,7 @@ export class PrCommandComponent {
     { name: 'list', description: 'List pull requests for a repository' },
     { name: 'view', description: 'View pull request details' },
     { name: 'create', description: 'Create a new pull request' },
+    { name: 'edit', description: 'Edit a pull request title and/or description' },
     { name: 'merge', description: 'Merge a pull request' },
     { name: 'approve', description: 'Approve a pull request' },
     { name: 'decline', description: 'Decline a pull request' },
@@ -123,6 +124,11 @@ export class PrCommandComponent {
       description: 'Shows detailed information about PR #42.'
     },
     {
+      title: 'Edit a pull request description',
+      command: 'bitbucket pr edit myworkspace/myrepo 42',
+      description: 'Opens $EDITOR prefilled with the current description. Pass --body to set it directly, or --title to change the title.'
+    },
+    {
       title: 'Merge a pull request',
       command: 'bitbucket pr merge myworkspace/myrepo 42 --strategy squash',
       description: 'Merges PR #42 using squash merge strategy.'
@@ -139,5 +145,7 @@ export class PrCommandComponent {
     { flag: '--limit <N>', description: 'Number of results to show (default: 25)' },
     { flag: '--web', description: 'Open in browser instead of showing in terminal' },
     { flag: '--strategy <STRATEGY>', description: 'Merge strategy (merge-commit, squash, fast-forward)' },
+    { flag: '--title <TITLE>', description: 'New title when editing a pull request' },
+    { flag: '--body <BODY>', description: 'New description when editing (skips the editor)' },
   ];
 }

--- a/src/cli/pr.rs
+++ b/src/cli/pr.rs
@@ -64,6 +64,24 @@ pub enum PrCommands {
         close_source_branch: bool,
     },
 
+    /// Edit a pull request's title and/or description
+    Edit {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        id: u64,
+
+        /// New title
+        #[arg(short, long)]
+        title: Option<String>,
+
+        /// New description. If omitted (and no other flag is given), $EDITOR
+        /// opens prefilled with the current description.
+        #[arg(short = 'b', long)]
+        body: Option<String>,
+    },
+
     /// Merge a pull request
     Merge {
         /// Repository in format workspace/repo-slug
@@ -406,6 +424,66 @@ impl PrCommands {
                 println!("{} Created pull request #{}", "✓".green(), pr.id);
 
                 if let Some(links) = &pr.links {
+                    if let Some(html) = &links.html {
+                        println!("{} {}", "URL:".dimmed(), html.href.cyan());
+                    }
+                }
+
+                Ok(())
+            }
+
+            PrCommands::Edit {
+                repo,
+                id,
+                title,
+                body,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let pr = client.get_pull_request(&workspace, &repo_slug, id).await?;
+
+                // If any flag is provided, the command is non-interactive and
+                // updates exactly the given fields. If no flag is provided, open
+                // the editor prefilled with the current description.
+                let interactive = title.is_none() && body.is_none();
+
+                let new_description = if let Some(body) = body {
+                    Some(body)
+                } else if interactive {
+                    let current = pr.description.clone().unwrap_or_default();
+                    match dialoguer::Editor::new().edit(&current)? {
+                        Some(edited) if edited != current => Some(edited),
+                        _ => {
+                            println!("No changes made to pull request #{}", id);
+                            return Ok(());
+                        }
+                    }
+                } else {
+                    None
+                };
+
+                // On a description-only change, pass the current title through so
+                // Bitbucket's PUT does not reset it.
+                let effective_title = match (&title, &new_description) {
+                    (Some(t), _) => Some(t.as_str()),
+                    (None, Some(_)) => Some(pr.title.as_str()),
+                    (None, None) => None,
+                };
+
+                let updated = client
+                    .update_pull_request(
+                        &workspace,
+                        &repo_slug,
+                        id,
+                        effective_title,
+                        new_description.as_deref(),
+                    )
+                    .await?;
+
+                println!("{} Updated pull request #{}", "✓".green(), updated.id);
+
+                if let Some(links) = &updated.links {
                     if let Some(html) = &links.html {
                         println!("{} {}", "URL:".dimmed(), html.href.cyan());
                     }


### PR DESCRIPTION


## Description

Adds a new `bitbucket pr edit <repo> <id>` subcommand. With no flags it opens $EDITOR prefilled with the current description; `--body` sets the description non-interactively and `--title` updates the title. On a description-only change the current title is passed through so Bitbucket's PUT does not reset it. Reuses the existing update_pull_request API method.

Fixes #(issue)

## Type of Change

<!-- Please check the relevant option. -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] 🧪 Test updates

## Checklist

<!-- Please check all that apply. -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

