### PR TITLE
feat!: comprehensive Bitbucket API coverage (v1.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,73 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-07-21
+
+### Added
+
+- Global `--output <table|json>` flag on every command; `--output json` emits
+  raw pretty-printed JSON for scripting.
+- New top-level `user` command: `whoami`, `view`, `emails`.
+- repo: new subcommand groups `branch`, `tag`, `commit`, `file`, `webhook`,
+  `branch-restriction`, `reviewer`, `permission`, `deploy-key`, `environment`,
+  `deployment`, and `branching-model`; new `watchers` and `forks` commands;
+  `download get`; `list` filters (`--role`, `-q/--query`, `--sort`, `--page`);
+  `create` flags `--language`, `--issues`, `--wiki`, `--website`, and
+  `--main-branch`; `update --website`.
+- pr: new `edit`, `unapprove`, `request-changes`, `unrequest-changes`,
+  `commits`, `statuses`, `diffstat`, `activity`, and `patch` commands; a `task`
+  group (`list`, `add`, `resolve`, `reopen`, `delete`); comment management
+  (`edit-comment`, `delete-comment`, `resolve-comment`, `unresolve-comment`);
+  `create --reviewers`; `list` accepts a repeatable `--state` plus
+  `-q/--query`, `--sort`, and `--page`; `comment --path/--line/--parent` for
+  inline and threaded comments.
+- issue: new `edit`, `delete`, `comments`, `vote`/`unvote`, `watch`/`unwatch`,
+  `changes`, `components`, `milestones`, `versions`, an `attachment` group
+  (`list`, `add`, `delete`), `edit-comment`, and `delete-comment` commands;
+  `list` filters (`--kind`, `--priority`, `--assignee`, `--reporter`,
+  `-q/--query`, `--sort`, `--page`);
+  `create --assignee/--component/--milestone/--version`; `view --comments`.
+- pipeline: `trigger --var/--secured-var/--commit`; `list --status/
+  --target-branch/--sort/--page`; `view --step/--full-logs`; `stop --uuid`;
+  new `variable`, `workspace-variable`, `schedule`, `cache`, `config`, and
+  `rerun` commands.
+- workspace: new `view`, `members`, and `permissions` commands and a `project`
+  group (`list`, `view`, `create`, `edit`, `delete`); `list` gained `--role`,
+  `-q/--query`, `--sort`, `--limit`, and `--all`.
+
+### Changed
+
+- `workspace list` now fetches a single page by default and supports filter
+  flags; pass `--all` to fetch every page as before.
+- `issue list` now composes the individual filter flags into a single BBQL
+  `q=` expression; `--query` overrides the individual flags.
+- Library API: `BitbucketClient::update_pull_request` now takes an
+  `UpdatePullRequestRequest` body; `BitbucketClient::list_issue_comments` now
+  takes a `pagelen: Option<u32>` argument; `models::UserRef` has been reshaped
+  to optional `uuid`/`username` fields. Public request/filter structs are now
+  `#[non_exhaustive]`, and the internal `*_filtered` client methods and their
+  filter structs are `pub(crate)`, so the stable library surface is smaller.
+- Config: the unused `[defaults] repository` and `[display]` (`color`, `pager`)
+  keys have been removed; they were never read.
+
+### Fixed
+
+- `pr checkout` no longer fetches from the wrong repository: it verifies that
+  `origin` points at the PR's repository, refuses PRs that come from forks
+  (with instructions to fetch manually), and fast-forwards a stale local
+  branch to the fetched tip instead of silently reusing it.
+- `pipeline trigger --wait` no longer hangs forever on pipelines that enter
+  the Paused state; it now reports that a manual resume is required.
+- The `User-Agent` header now carries the real crate version.
+- `UserLinks.self` now deserializes correctly from the API's `self` key.
+
+### Removed
+
+- Dead `get_main_branch` and `list_branches` functions from the repos API
+  module (superseded by the refs API).
+- Dead `defaults.repository` config field.
+- Dead TUI `load_all_data` method.
+
 ## [0.4.0] - 2026-07-21
 
 ### Breaking

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,25 @@ cargo fmt
 - Keep functions focused and small
 - Use meaningful variable and function names
 
+### Command taxonomy
+
+The top-level commands (`auth`, `repo`, `pr`, `issue`, `pipeline`, `workspace`,
+`user`) mirror the major Bitbucket resource types. A resource that is *owned by
+a repository* is a subcommand group under `repo` (e.g. `repo branch`,
+`repo webhook`, `repo permission`) rather than a new top-level command. `pr`,
+`issue`, and `pipeline` are top-level for historical reasons and because they
+are the day-to-day nouns; do not add new top-level commands for repo-scoped
+resources. When a resource has more than one verb (list/create/delete), group
+them under a subcommand (`repo download {list,get,delete}`), never as flat
+sibling verbs (`download-list`, `download-get`).
+
+### Pagination and limits
+
+All paginated list commands share one policy via `cli::pagination`: a
+`--limit` (default 25) capped at 100 with a notice, using `effective_limit`.
+Do not add a per-command `MAX_LIMIT`, a clap `range(1..=100)` validator, or a
+bespoke cap — reuse the shared helper so behavior and wording stay uniform.
+
 ## Commit Messages
 
 - Use the present tense ("Add feature" not "Added feature")

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +139,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,10 +263,11 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitbucket-cli"
-version = "0.4.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "base64",
+ "bytes",
  "chrono",
  "clap",
  "colored",
@@ -506,6 +525,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +607,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,8 +631,6 @@ dependencies = [
  "num-traits",
  "oorandom",
  "page_size",
- "plotters",
- "rayon",
  "regex",
  "serde",
  "serde_json",
@@ -603,25 +646,6 @@ checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -926,6 +950,16 @@ name = "find-msvc-tools"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1619,6 +1653,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1926,34 +1970,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
-
-[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,26 +2195,6 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
-]
-
-[[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -2641,6 +2637,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2899,6 +2901,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2970,13 +2985,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitbucket-cli"
-version = "0.4.0"
+version = "1.0.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A powerful command-line interface for Bitbucket Cloud - manage repos, PRs, issues, and pipelines from your terminal with OAuth 2.0"
@@ -33,7 +33,8 @@ crossterm = "0.29"
 
 # Async runtime & HTTP
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12", features = ["json", "rustls-tls", "multipart"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "multipart", "gzip"], default-features = false }
+bytes = "1"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -73,7 +74,7 @@ keyring = { version = "3", default-features = false, features = ["apple-native"]
 keyring = { version = "3", default-features = false, features = ["windows-native"] }
 
 [dev-dependencies]
-criterion = { version = "0.8", features = ["html_reports"] }
+criterion = { version = "0.8", default-features = false }
 
 [lib]
 name = "bitbucket_cli"

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ You'll need to create an OAuth consumer first:
 bitbucket auth login --api-key
 ```
 
-You'll need to create an HTTP access token:
-1. Go to [Personal settings → HTTP access tokens](https://bitbucket.org/account/settings/app-passwords/)
-2. Create a new token with required permissions
-3. Enter your username and token when prompted
+You'll need to create an API token:
+1. Go to your [Bitbucket personal settings](https://bitbucket.org/account/settings/) and open the API tokens section
+2. Create a new token with the required permissions
+3. Enter your Atlassian account email and token when prompted (or pass `--email` and `--token` for non-interactive use)
 
 **Note:** App passwords are deprecated by Atlassian. OAuth 2.0 is the preferred method.
 
@@ -143,16 +143,31 @@ bitbucket repo download upload myworkspace/myrepo screenshot.png
 bitbucket tui --workspace myworkspace
 ```
 
+### Scripting
+
+Every command accepts a global `--output` flag. The default (`table`) prints
+human-readable tables; `--output json` emits the raw data as pretty-printed
+JSON for piping into `jq` or scripts:
+
+```bash
+# IDs and titles of open pull requests
+bitbucket pr list myworkspace/myrepo --output json | jq -r '.[] | "\(.id)\t\(.title)"'
+
+# Machine-readable repository details
+bitbucket repo view myworkspace/myrepo --output json
+```
+
 ## 📖 Commands
 
 | Command | Description |
 |---------|-------------|
 | `bitbucket auth` | Manage authentication (login, logout, status) |
-| `bitbucket repo` | Manage repositories (list, view, clone, create, update, move, fork, delete, download) |
-| `bitbucket pr` | Manage pull requests (list, view, create, merge, approve, decline, checkout, diff, comment, list-comments, view-comment, pipelines) |
-| `bitbucket issue` | Manage issues (list, view, create, comment, close, reopen) |
-| `bitbucket pipeline` | Manage pipelines (list, view, trigger, stop) |
-| `bitbucket workspace` | Manage workspaces (list) |
+| `bitbucket repo` | Manage repositories (list, view, clone, create, update, move, fork, delete, watchers, forks, downloads), plus branch/tag/commit/file browsing, webhooks, branch restrictions, default reviewers, permissions, deploy keys, environments, deployments, and the branching model |
+| `bitbucket pr` | Manage pull requests (list, view, create, edit, merge, approve/unapprove, request-changes, decline, checkout, diff/diffstat, patch, commits, statuses, activity, pipelines), plus comments and tasks |
+| `bitbucket issue` | Manage issues (list, view, create, edit, delete, close, reopen, vote, watch), plus comments, attachments, change log, and tracker components/milestones/versions |
+| `bitbucket pipeline` | Manage pipelines (list, view, trigger, rerun, stop, config), plus repository and workspace variables, schedules, and caches |
+| `bitbucket workspace` | Manage workspaces (list, view, members, permissions) and their projects |
+| `bitbucket user` | Inspect user accounts (whoami, view, emails) |
 | `bitbucket tui` | Launch interactive terminal UI |
 
 ## 🖥️ TUI Mode

--- a/docs/SMOKE-TESTS.md
+++ b/docs/SMOKE-TESTS.md
@@ -1,0 +1,50 @@
+# Live-API Smoke Tests
+
+Most of the CLI is covered by unit tests, but those assert request/response
+*shapes* against what we believe the Bitbucket Cloud REST API v2.0 expects —
+not against a live instance. The mutating endpoints below were implemented
+from documentation and have **not** been exercised against a real workspace.
+Run this checklist against a scratch repository before trusting them, and tick
+each item once confirmed. If one fails, the note names the most likely cause.
+
+> This file exists so that "known-unverified" is distinguishable from a
+> regression when the first bug report arrives. Do not delete an item; mark it
+> verified with the date and CLI version instead.
+
+## Write paths pending live verification
+
+- [ ] `repo reviewer add <repo> <account>` — `PUT .../default-reviewers/{target}`
+      with an empty `{}` body. Uncertainty: the `{target}` identifier may need
+      to be an account ID / `{uuid}` rather than a username (GDPR migration).
+- [ ] `repo permission grant-user <repo> <user> --permission write` —
+      `PUT .../permissions-config/users/{selected}` with `{"permission": …}`.
+      Confirm the `permissions-config` path spelling and that `{selected}` is an
+      account ID.
+- [ ] `repo permission grant-group <repo> <group> --permission read` — same,
+      `.../permissions-config/groups/{slug}`.
+- [ ] `issue attachment add <repo> <id> <file>` — multipart `POST .../issues/{id}/attachments`.
+      The multipart field name is `files`; Bitbucket derives the attachment name
+      from the part filename, so this should be fine, but confirm the upload
+      succeeds and the file appears.
+- [ ] `repo branch-restriction create <repo> --kind … --pattern …` —
+      `POST .../branch-restrictions`. Some kinds require a non-empty `users`/
+      `groups` list (now settable via `--user`/`--group`); confirm the body is
+      accepted for the kind you use.
+- [ ] `repo environment create <repo> <name> --type Production` —
+      `POST .../environments/` with nested `environment_type`. Some accounts may
+      require a `rank` field.
+- [ ] `pipeline schedule create <repo> --branch … --cron …` —
+      `POST .../pipelines_config/schedules/`. Confirm the `selector.type`
+      (`branches`) is accepted for your pipeline configuration.
+- [ ] `pipeline variable set <repo> …` and `pipeline workspace-variable set …`
+      — the repo path is `.../pipelines_config/variables/` (underscore) and the
+      workspace path is `.../pipelines-config/variables/` (hyphen), both with a
+      trailing slash. Confirm the create POST is accepted (a missing trailing
+      slash would redirect the POST to a GET and silently not create).
+- [ ] `pipeline cache list/delete <repo>` — `.../pipelines-config/caches/`
+      (hyphen). Confirm the path returns 200, not 404.
+- [ ] `pipeline config <repo> --next-build-number N` —
+      `PUT .../pipelines_config/build_number` with `{"next": N}`.
+- [ ] `pr create/edit --reviewers <account>` — reviewers serialize as
+      `{"uuid": …}` / `{"username": …}`. Confirm reviewers are actually attached
+      (GDPR-migrated Bitbucket ignores `username`).

--- a/docs/package.json
+++ b/docs/package.json
@@ -25,13 +25,11 @@
     "@angular/common": "^21.0.0",
     "@angular/compiler": "^21.0.0",
     "@angular/core": "^21.0.0",
-    "@angular/forms": "^21.0.0",
     "@angular/platform-browser": "^21.0.0",
     "@angular/router": "^21.0.0",
     "@fortawesome/angular-fontawesome": "^4.0.0",
     "@fortawesome/fontawesome-svg-core": "^7.2.0",
     "@fortawesome/free-brands-svg-icons": "^7.2.0",
-    "@fortawesome/free-regular-svg-icons": "^7.2.0",
     "@fortawesome/free-solid-svg-icons": "^7.1.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@angular/core':
         specifier: ^21.0.0
         version: 21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.2)
-      '@angular/forms':
-        specifier: ^21.0.0
-        version: 21.0.6(@angular/common@21.0.6(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.2))(@angular/platform-browser@21.0.6(@angular/common@21.0.6(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@angular/platform-browser':
         specifier: ^21.0.0
         version: 21.0.6(@angular/common@21.0.6(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.2))
@@ -33,9 +30,6 @@ importers:
         specifier: ^7.2.0
         version: 7.2.0
       '@fortawesome/free-brands-svg-icons':
-        specifier: ^7.2.0
-        version: 7.2.0
-      '@fortawesome/free-regular-svg-icons':
         specifier: ^7.2.0
         version: 7.2.0
       '@fortawesome/free-solid-svg-icons':
@@ -247,15 +241,6 @@ packages:
         optional: true
       zone.js:
         optional: true
-
-  '@angular/forms@21.0.6':
-    resolution: {integrity: sha512-aAkAAKuUrP8U7R4aH/HbmG/CXP90GlML77ECBI5b4qCSb+bvaTEYsaf85mCyTpr9jvGkia2LTe42hPcOuyzdsQ==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    peerDependencies:
-      '@angular/common': 21.0.6
-      '@angular/core': 21.0.6
-      '@angular/platform-browser': 21.0.6
-      rxjs: ^6.5.3 || ^7.4.0
 
   '@angular/platform-browser@21.0.6':
     resolution: {integrity: sha512-tPk8rlUEBPXIUPRYq6Xu7QhJgKtnVr0dOHHuhyi70biKTupr5VikpZC5X9dy2Q3H3zYbK6MHC6384YMuwfU2kg==}
@@ -900,10 +885,6 @@ packages:
     resolution: {integrity: sha512-VNG8xqOip1JuJcC3zsVsKRQ60oXG9+oYNDCosjoU/H9pgYmLTEwWw8pE0jhPz/JWdHeUuK6+NQ3qsM4gIbdbYQ==}
     engines: {node: '>=6'}
 
-  '@fortawesome/free-regular-svg-icons@7.2.0':
-    resolution: {integrity: sha512-iycmlN51EULlQ4D/UU9WZnHiN0CvjJ2TuuCrAh+1MVdzD+4ViKYH2deNAll4XAAYlZa8WAefHR5taSK8hYmSMw==}
-    engines: {node: '>=6'}
-
   '@fortawesome/free-solid-svg-icons@7.1.0':
     resolution: {integrity: sha512-Udu3K7SzAo9N013qt7qmm22/wo2hADdheXtBfxFTecp+ogsc0caQNRKEb7pkvvagUGOpG9wJC1ViH6WXs8oXIA==}
     engines: {node: '>=6'}
@@ -1206,42 +1187,49 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
     resolution: {integrity: sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-openharmony-arm64@1.1.1':
     resolution: {integrity: sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==}
@@ -1347,36 +1335,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -1435,24 +1429,28 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.47':
     resolution: {integrity: sha512-doozc/Goe7qRCSnzfJbFINTHsMktqmZQmweull6hsZZ9sjNWQ6BWQnbvOlfZJe4xE5NxM1NhPnY5Giqnl3ZrYQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.47':
     resolution: {integrity: sha512-fodvSMf6Aqwa0wEUSTPewmmZOD44rc5Tpr5p9NkwQ6W1SSpUKzD3SwpJIgANDOhwiYhDuiIaYPGB7Ujkx1q0UQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.47':
     resolution: {integrity: sha512-Rxm5hYc0mGjwLh5sjlGmMygxAaV2gnsx7CNm2lsb47oyt5UQyPDZf3GP/ct8BEcwuikdqzsrrlIp8+kCSvMFNQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.47':
     resolution: {integrity: sha512-YakuVe+Gc87jjxazBL34hbr8RJpRuFBhun7NEqoChVDlH5FLhLXjAPHqZd990TVGVNkemourf817Z8u2fONS8w==}
@@ -1550,121 +1548,145 @@ packages:
     resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.62.0':
     resolution: {integrity: sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.54.0':
     resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.0':
     resolution: {integrity: sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.54.0':
     resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.0':
     resolution: {integrity: sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.54.0':
     resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.62.0':
     resolution: {integrity: sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.54.0':
     resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.0':
     resolution: {integrity: sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.0':
     resolution: {integrity: sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.54.0':
     resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.0':
     resolution: {integrity: sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.0':
     resolution: {integrity: sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.54.0':
     resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.0':
     resolution: {integrity: sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.54.0':
     resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.0':
     resolution: {integrity: sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.54.0':
     resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.0':
     resolution: {integrity: sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.54.0':
     resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.0':
     resolution: {integrity: sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.54.0':
     resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.62.0':
     resolution: {integrity: sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.0':
     resolution: {integrity: sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==}
@@ -1790,24 +1812,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -2535,24 +2561,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -3668,15 +3698,6 @@ snapshots:
     optionalDependencies:
       '@angular/compiler': 21.0.6
 
-  '@angular/forms@21.0.6(@angular/common@21.0.6(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.2))(@angular/platform-browser@21.0.6(@angular/common@21.0.6(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.2)))(rxjs@7.8.2)':
-    dependencies:
-      '@angular/common': 21.0.6(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.2))(rxjs@7.8.2)
-      '@angular/core': 21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.2)
-      '@angular/platform-browser': 21.0.6(@angular/common@21.0.6(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.2))
-      '@standard-schema/spec': 1.1.0
-      rxjs: 7.8.2
-      tslib: 2.8.1
-
   '@angular/platform-browser@21.0.6(@angular/common@21.0.6(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.2))':
     dependencies:
       '@angular/common': 21.0.6(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.2))(rxjs@7.8.2)
@@ -4106,10 +4127,6 @@ snapshots:
       '@fortawesome/fontawesome-common-types': 7.2.0
 
   '@fortawesome/free-brands-svg-icons@7.2.0':
-    dependencies:
-      '@fortawesome/fontawesome-common-types': 7.2.0
-
-  '@fortawesome/free-regular-svg-icons@7.2.0':
     dependencies:
       '@fortawesome/fontawesome-common-types': 7.2.0
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -2,7 +2,7 @@
 
 > A powerful command-line interface for Bitbucket Cloud written in Rust
 
-A feature-rich CLI tool for managing Bitbucket Cloud resources directly from your terminal. It supports repository management, pull requests, issue tracking, CI/CD pipelines, and includes an interactive terminal UI (TUI) for visual browsing. Authentication supports OAuth 2.0 with secure keyring storage and API key fallback for CI/automation scenarios.
+A feature-rich CLI tool for managing Bitbucket Cloud resources directly from your terminal. It supports repository management, pull requests, issue tracking, CI/CD pipelines, workspaces, and user accounts, and includes an interactive terminal UI (TUI) for visual browsing. Authentication supports OAuth 2.0 with secure keyring storage and API key fallback for CI/automation scenarios. Every command accepts a global `--output <table|json>` flag: the default `table` prints human-readable tables, while `--output json` emits raw pretty-printed JSON for scripting and piping into tools like jq.
 
 ## Links
 
@@ -10,13 +10,38 @@ A feature-rich CLI tool for managing Bitbucket Cloud resources directly from you
 - [GitHub Repository](https://github.com/pegasusheavy/bitbucket-cli)
 - [Crates.io Package](https://crates.io/crates/bitbucket-cli)
 
+## Commands
+
+- `bitbucket auth`: login (OAuth 2.0 or API key, with --email/--token for non-interactive use), logout, status
+- `bitbucket repo`: list (--role, -q/--query, --sort, --page), view, clone, create (--description, --public, --project, --fork-policy, --language, --issues, --wiki, --website, --main-branch), update (same flags plus --name, --private), move, fork, delete, watchers, forks, download (upload, list, get, delete)
+- `bitbucket repo branch`: list, create, view, delete
+- `bitbucket repo tag`: list, create, view, delete
+- `bitbucket repo commit`: list, view, diff
+- `bitbucket repo file`: ls, cat, history (all accept --ref)
+- `bitbucket repo webhook`: list, create, view, update, delete
+- `bitbucket repo branch-restriction`: list, create, delete
+- `bitbucket repo reviewer`: list, add, remove (default reviewers)
+- `bitbucket repo permission`: list-users, list-groups, grant-user, revoke-user, grant-group, revoke-group
+- `bitbucket repo deploy-key`: list, add, delete
+- `bitbucket repo environment`: list, create, delete
+- `bitbucket repo deployment`: list, view
+- `bitbucket repo branching-model`: view, set (--development, --production)
+- `bitbucket pr`: list (repeatable --state, -q/--query, --sort, --page), view, create (--reviewers), edit, merge, approve, unapprove, request-changes, unrequest-changes, decline, checkout, diff, diffstat, patch, commits, statuses, activity, comment (--path/--line for inline, --parent for replies), edit-comment, delete-comment, resolve-comment, unresolve-comment, list-comments, view-comment, task (list, add, resolve, reopen, delete), pipelines
+- `bitbucket issue`: list (--state, --kind, --priority, --assignee, --reporter, -q/--query, --sort, --page), view (--comments), create (--assignee, --component, --milestone, --version), edit, delete, close, reopen, comment, comments, edit-comment, delete-comment, changes, vote, unvote, watch, unwatch, components, milestones, versions, attachment (list, add, delete)
+- `bitbucket pipeline`: list (--status, --target-branch, --sort, --page), view (--logs, --step, --full-logs), trigger (--branch, --commit, --pipeline, --var, --secured-var, --wait), stop (--build or --uuid), rerun, config, variable (list, set, delete), workspace-variable (list, set, delete), schedule (list, create, delete), cache (list, delete)
+- `bitbucket workspace`: list (--role, -q/--query, --sort, --limit, --all), view, members, permissions (--repo), project (list, view, create, edit, delete)
+- `bitbucket user`: whoami, view, emails
+- `bitbucket tui`: interactive terminal UI
+
 ## Key Features
 
-- Repository management: list, view, clone, create, update, move, fork, and delete repositories, plus download artifact management (upload, list, delete)
-- Pull request workflows: list, view, create, merge, approve, decline, checkout, diff, comment, list-comments, view-comment, and pipelines
-- Issue tracking: list, view, create, comment on, close, and reopen issues
-- Pipeline management: list, view, trigger, and stop CI/CD pipelines
-- Workspace management: list workspaces
+- Repository management: list, view, clone, create, update, move, fork, and delete repositories; watchers and forks listings; downloads area management; branch, tag, commit, and file browsing; webhooks; branch restrictions; default reviewers; user/group permissions; deploy keys; deployment environments and deployments; branching model
+- Pull request workflows: create, edit, review (approve/unapprove, request-changes), merge, decline, checkout, diff/diffstat/patch, commits, build statuses, activity feed, inline and threaded comments with resolve/unresolve, and PR tasks
+- Issue tracking: full lifecycle (create, edit, close, reopen, delete), filtered listings, comments, attachments, votes, watching, change log, and tracker components/milestones/versions
+- Pipeline management: trigger with variables (including secured) on a branch or commit, wait for completion, view step logs, stop, rerun, pipelines configuration, repository and workspace variables, schedules, and caches
+- Workspace management: list/view workspaces, members, permissions, and projects
+- User accounts: whoami, public profiles, and account emails
+- Scripting: global `--output json` flag on every command for raw JSON output
 - Interactive TUI mode with keyboard-driven navigation
 - Secure authentication via OAuth 2.0 (preferred) or API key fallback
 - Cross-platform: Linux (deb, rpm, Arch, Alpine), Windows (MSI), and from source
@@ -45,8 +70,14 @@ bitbucket repo list myworkspace
 # List pull requests
 bitbucket pr list myworkspace/myrepo
 
-# Create a pull request
-bitbucket pr create myworkspace/myrepo --title "My PR" --source feature-branch
+# Create a pull request with reviewers
+bitbucket pr create myworkspace/myrepo --title "My PR" --source feature-branch --reviewers alice,bob
+
+# Trigger a pipeline with variables and wait for it
+bitbucket pipeline trigger myworkspace/myrepo --branch main --var ENV=staging --wait
+
+# Raw JSON output for scripting
+bitbucket pr list myworkspace/myrepo --output json | jq -r '.[] | "\(.id)\t\(.title)"'
 
 # Launch interactive TUI
 bitbucket tui --workspace myworkspace

--- a/docs/public/sitemap.xml
+++ b/docs/public/sitemap.xml
@@ -55,4 +55,9 @@
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
+  <url>
+    <loc>https://pegasusheavy.github.io/bitbucket-cli/commands/user</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>

--- a/docs/src/app/app.config.ts
+++ b/docs/src/app/app.config.ts
@@ -3,40 +3,9 @@ import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
 
-// FontAwesome configuration
-import { FaConfig, FaIconLibrary } from '@fortawesome/angular-fontawesome';
-import {
-  faHome, faDownload, faLock, faCog, faKey, faFolder, faCodeBranch,
-  faBug, faBolt, faTerminal, faScroll, faWrench, faSearch, faBars,
-  faChevronRight, faArrowRight, faArrowLeft, faCopy, faCheck, faXmark,
-  faExternalLinkAlt, faBook, faRocket, faShieldAlt, faCode, faPlay,
-  faStop, faEye, faPlus, faComment, faTimes, faInfoCircle, faCheckCircle,
-  faExclamationTriangle, faQuestionCircle, faList, faLayerGroup
-} from '@fortawesome/free-solid-svg-icons';
-import { faGithub, faBitbucket } from '@fortawesome/free-brands-svg-icons';
-
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideRouter(routes)
   ]
 };
-
-// Icon library setup - call this in main.ts
-export function setupFontAwesome(library: FaIconLibrary, config: FaConfig) {
-  // Add icons to library
-  library.addIcons(
-    // Solid icons
-    faHome, faDownload, faLock, faCog, faKey, faFolder, faCodeBranch,
-    faBug, faBolt, faTerminal, faScroll, faWrench, faSearch, faBars,
-    faChevronRight, faArrowRight, faArrowLeft, faCopy, faCheck, faXmark,
-    faExternalLinkAlt, faBook, faRocket, faShieldAlt, faCode, faPlay,
-    faStop, faEye, faPlus, faComment, faTimes, faInfoCircle, faCheckCircle,
-    faExclamationTriangle, faQuestionCircle, faList, faLayerGroup,
-    // Brand icons
-    faGithub, faBitbucket
-  );
-
-  // Optional: Set default prefix
-  config.defaultPrefix = 'fas';
-}

--- a/docs/src/app/app.routes.ts
+++ b/docs/src/app/app.routes.ts
@@ -46,6 +46,10 @@ export const routes: Routes = [
     loadComponent: () => import('./pages/commands/workspace/workspace.component').then(m => m.WorkspaceCommandComponent)
   },
   {
+    path: 'commands/user',
+    loadComponent: () => import('./pages/commands/user/user.component').then(m => m.UserCommandComponent)
+  },
+  {
     path: '**',
     loadComponent: () => import('./pages/not-found/not-found.component').then(m => m.NotFoundComponent)
   }

--- a/docs/src/app/components/header/header.component.ts
+++ b/docs/src/app/components/header/header.component.ts
@@ -46,7 +46,7 @@ import { faGithub } from '@fortawesome/free-brands-svg-icons';
           </a>
 
           <span class="hidden sm:inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-[var(--color-bitbucket-blue-50)] text-[var(--color-bitbucket-blue)]">
-            v0.4.0
+            v1.0.0
           </span>
         </div>
       </div>

--- a/docs/src/app/components/sidebar/sidebar.component.ts
+++ b/docs/src/app/components/sidebar/sidebar.component.ts
@@ -5,7 +5,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import {
   faHome, faDownload, faLock, faCog, faKey, faFolder, faCodeBranch,
-  faBug, faBolt, faBuilding, faTerminal
+  faBug, faBolt, faBuilding, faTerminal, faUser
 } from '@fortawesome/free-solid-svg-icons';
 import { faGithub, faBitbucket } from '@fortawesome/free-brands-svg-icons';
 
@@ -96,6 +96,7 @@ export class SidebarComponent {
         { label: 'issue', path: '/commands/issue', icon: faBug },
         { label: 'pipeline', path: '/commands/pipeline', icon: faBolt },
         { label: 'workspace', path: '/commands/workspace', icon: faBuilding },
+        { label: 'user', path: '/commands/user', icon: faUser },
       ]
     },
     {

--- a/docs/src/app/pages/commands/issue/issue.component.ts
+++ b/docs/src/app/pages/commands/issue/issue.component.ts
@@ -60,17 +60,35 @@ import { CommonModule } from '@angular/common';
 })
 export class IssueCommandComponent {
   subcommands = [
-    { name: 'list', description: 'List issues' },
-    { name: 'view', description: 'View issue details' },
-    { name: 'create', description: 'Create a new issue' },
-    { name: 'comment', description: 'Add a comment to an issue' },
+    { name: 'list', description: 'List issues (--state, --kind, --priority, --assignee, --reporter, -q/--query, --sort, --page)' },
+    { name: 'view', description: 'View issue details (--comments to include the discussion)' },
+    { name: 'create', description: 'Create a new issue (--title, --body, --kind, --priority, --assignee, --component, --milestone, --version)' },
+    { name: 'edit', description: "Edit an issue's fields (--title, --body, --kind, --priority, --assignee, --state)" },
+    { name: 'delete', description: 'Delete an issue' },
     { name: 'close', description: 'Close an issue' },
     { name: 'reopen', description: 'Reopen an issue' },
+    { name: 'comment', description: 'Add a comment to an issue' },
+    { name: 'comments', description: 'List comments on an issue' },
+    { name: 'edit-comment', description: 'Edit a comment on an issue' },
+    { name: 'delete-comment', description: 'Delete a comment from an issue' },
+    { name: 'changes', description: 'List the change log of an issue' },
+    { name: 'vote', description: 'Vote for an issue' },
+    { name: 'unvote', description: 'Remove your vote from an issue' },
+    { name: 'watch', description: 'Watch an issue' },
+    { name: 'unwatch', description: 'Stop watching an issue' },
+    { name: 'components', description: 'List the components defined in the issue tracker' },
+    { name: 'milestones', description: 'List the milestones defined in the issue tracker' },
+    { name: 'versions', description: 'List the versions defined in the issue tracker' },
+    { name: 'attachment', description: 'Manage issue attachments (list, add, delete)' },
   ];
 
   examples = [
     { title: 'List issues', command: 'bitbucket issue list myworkspace/myrepo' },
-    { title: 'Create an issue', command: 'bitbucket issue create myworkspace/myrepo --title "Bug report" --kind bug' },
+    { title: 'List critical open bugs', command: 'bitbucket issue list myworkspace/myrepo --state open --kind bug --priority critical' },
+    { title: 'Create an issue', command: 'bitbucket issue create myworkspace/myrepo --title "Bug report" --kind bug --priority major --component backend' },
+    { title: 'View an issue with its comments', command: 'bitbucket issue view myworkspace/myrepo 42 --comments' },
+    { title: 'Edit an issue', command: 'bitbucket issue edit myworkspace/myrepo 42 --priority blocker --assignee 557058:aaaa-bbbb' },
+    { title: 'Attach a file', command: 'bitbucket issue attachment add myworkspace/myrepo 42 screenshot.png' },
     { title: 'Close an issue', command: 'bitbucket issue close myworkspace/myrepo 42' },
   ];
 }

--- a/docs/src/app/pages/commands/pipeline/pipeline.component.ts
+++ b/docs/src/app/pages/commands/pipeline/pipeline.component.ts
@@ -60,16 +60,28 @@ import { CommonModule } from '@angular/common';
 })
 export class PipelineCommandComponent {
   subcommands = [
-    { name: 'list', description: 'List pipelines' },
-    { name: 'view', description: 'View pipeline details' },
-    { name: 'trigger', description: 'Trigger a new pipeline' },
-    { name: 'stop', description: 'Stop a running pipeline' },
+    { name: 'list', description: 'List pipelines (--status, --target-branch, --sort, --page)' },
+    { name: 'view', description: 'View pipeline details (--logs, --step, --full-logs)' },
+    { name: 'trigger', description: 'Trigger a new pipeline (--branch, --commit, --pipeline, --var, --secured-var, --wait)' },
+    { name: 'stop', description: 'Stop a running pipeline (--build or --uuid)' },
+    { name: 'rerun', description: 'Re-run a pipeline by triggering an equivalent one' },
+    { name: 'config', description: 'View or update the repository pipelines configuration (--enable, --disable, --next-build-number)' },
+    { name: 'variable', description: 'Manage repository pipeline variables (list, set, delete)' },
+    { name: 'workspace-variable', description: 'Manage workspace-level pipeline variables (list, set, delete)' },
+    { name: 'schedule', description: 'Manage pipeline schedules (list, create, delete)' },
+    { name: 'cache', description: 'Manage pipeline dependency caches (list, delete)' },
   ];
 
   examples = [
     { title: 'List recent pipelines', command: 'bitbucket pipeline list myworkspace/myrepo' },
+    { title: 'List completed pipelines on main', command: 'bitbucket pipeline list myworkspace/myrepo --status COMPLETED --target-branch main' },
     { title: 'Trigger pipeline on main', command: 'bitbucket pipeline trigger myworkspace/myrepo --branch main' },
-    { title: 'Trigger and wait', command: 'bitbucket pipeline trigger myworkspace/myrepo --branch main --wait' },
+    { title: 'Trigger with variables and wait', command: 'bitbucket pipeline trigger myworkspace/myrepo --branch main --var ENV=staging --secured-var TOKEN=s3cret --wait' },
+    { title: 'Trigger a custom pipeline on a commit', command: 'bitbucket pipeline trigger myworkspace/myrepo --commit abc123 --pipeline deploy' },
     { title: 'View pipeline details', command: 'bitbucket pipeline view myworkspace/myrepo --build 123' },
+    { title: 'View full logs for one step', command: 'bitbucket pipeline view myworkspace/myrepo --build 123 --step 2 --full-logs' },
+    { title: 'Re-run a pipeline', command: 'bitbucket pipeline rerun myworkspace/myrepo --build 123' },
+    { title: 'Set a secured pipeline variable', command: 'bitbucket pipeline variable set myworkspace/myrepo DEPLOY_KEY abc123 --secured' },
+    { title: 'Create a nightly schedule', command: 'bitbucket pipeline schedule create myworkspace/myrepo --branch main --cron "0 0 12 * * ? *"' },
   ];
 }

--- a/docs/src/app/pages/commands/pr/pr.component.ts
+++ b/docs/src/app/pages/commands/pr/pr.component.ts
@@ -95,17 +95,31 @@ import { CommonModule } from '@angular/common';
 })
 export class PrCommandComponent {
   subcommands = [
-    { name: 'list', description: 'List pull requests for a repository' },
+    { name: 'list', description: 'List pull requests (repeatable --state, -q/--query, --sort, --page, --limit)' },
     { name: 'view', description: 'View pull request details' },
-    { name: 'create', description: 'Create a new pull request' },
+    { name: 'create', description: 'Create a new pull request (--title, --source, --destination, --body, --close-source-branch, --reviewers)' },
+    { name: 'edit', description: 'Edit an existing pull request (--title, --body, --reviewers, --destination)' },
     { name: 'merge', description: 'Merge a pull request' },
     { name: 'approve', description: 'Approve a pull request' },
+    { name: 'unapprove', description: 'Remove your approval from a pull request' },
+    { name: 'request-changes', description: 'Request changes on a pull request' },
+    { name: 'unrequest-changes', description: 'Withdraw your request for changes' },
     { name: 'decline', description: 'Decline a pull request' },
-    { name: 'checkout', description: 'Checkout a PR branch locally' },
+    { name: 'checkout', description: 'Checkout a PR branch locally (verifies the origin remote and fast-forwards stale branches)' },
     { name: 'diff', description: 'View the diff for a pull request' },
-    { name: 'comment', description: 'Add a comment to a pull request' },
+    { name: 'diffstat', description: 'Show the per-file change summary' },
+    { name: 'patch', description: 'Print the patch (mbox-style) for a pull request' },
+    { name: 'commits', description: 'List commits on a pull request' },
+    { name: 'statuses', description: 'Show build statuses for a pull request' },
+    { name: 'activity', description: 'Show the activity feed for a pull request' },
+    { name: 'comment', description: 'Add a comment (--path/--line for inline, --parent for replies)' },
+    { name: 'edit-comment', description: 'Edit a comment on a pull request' },
+    { name: 'delete-comment', description: 'Delete a comment on a pull request' },
+    { name: 'resolve-comment', description: 'Resolve a comment thread' },
+    { name: 'unresolve-comment', description: 'Reopen a resolved comment thread' },
     { name: 'list-comments', description: 'List comments on a pull request' },
     { name: 'view-comment', description: 'View a specific comment on a pull request' },
+    { name: 'task', description: 'Manage tasks on a pull request (list, add, resolve, reopen, delete)' },
     { name: 'pipelines', description: "List pipelines for the PR's head commit" },
   ];
 
@@ -116,19 +130,34 @@ export class PrCommandComponent {
       description: 'Lists all open pull requests in the specified repository.'
     },
     {
-      title: 'Create a pull request',
-      command: 'bitbucket pr create myworkspace/myrepo --title "Add feature" --source feature-branch --destination main',
-      description: 'Creates a new pull request from feature-branch to main.'
+      title: 'List merged and declined pull requests',
+      command: 'bitbucket pr list myworkspace/myrepo --state merged --state declined',
+      description: 'The --state flag is repeatable to match several states at once.'
     },
     {
-      title: 'View pull request details',
-      command: 'bitbucket pr view myworkspace/myrepo 42',
-      description: 'Shows detailed information about PR #42.'
+      title: 'Create a pull request with reviewers',
+      command: 'bitbucket pr create myworkspace/myrepo --title "Add feature" --source feature-branch --destination main --reviewers alice,bob',
+      description: 'Creates a new pull request from feature-branch to main and assigns reviewers.'
+    },
+    {
+      title: 'Edit a pull request',
+      command: 'bitbucket pr edit myworkspace/myrepo 42 --title "New title" --destination develop',
+      description: 'Updates only the fields you pass; everything else is left unchanged.'
     },
     {
       title: 'Merge a pull request',
       command: 'bitbucket pr merge myworkspace/myrepo 42 --strategy squash',
       description: 'Merges PR #42 using squash merge strategy.'
+    },
+    {
+      title: 'Leave an inline comment',
+      command: 'bitbucket pr comment myworkspace/myrepo 42 --body "Typo here" --path src/main.rs --line 10',
+      description: 'Attaches the comment to line 10 of src/main.rs in the diff.'
+    },
+    {
+      title: 'Add a task to a pull request',
+      command: 'bitbucket pr task add myworkspace/myrepo 42 --body "Update the changelog"',
+      description: 'Tasks can then be resolved, reopened, or deleted with pr task resolve/reopen/delete.'
     },
     {
       title: 'Checkout PR locally',
@@ -138,9 +167,13 @@ export class PrCommandComponent {
   ];
 
   options = [
-    { flag: '--state <STATE>', description: 'Filter by state (open, merged, declined, superseded)' },
+    { flag: '--state <STATE>', description: 'Filter by state (open, merged, declined, superseded); repeatable' },
+    { flag: '-q, --query <QUERY>', description: 'Filter with a Bitbucket query (BBQL) expression' },
+    { flag: '--sort <FIELD>', description: 'Sort field, prefix with - for descending (e.g. -updated_on)' },
+    { flag: '--page <N>', description: 'Page number to fetch' },
     { flag: '--limit <N>', description: 'Number of results to show (default: 25)' },
     { flag: '--web', description: 'Open in browser instead of showing in terminal' },
     { flag: '--strategy <STRATEGY>', description: 'Merge strategy (merge-commit, squash, fast-forward)' },
+    { flag: '--reviewers <USERS>', description: 'Comma-separated reviewer usernames (create/edit)' },
   ];
 }

--- a/docs/src/app/pages/commands/repo/repo.component.ts
+++ b/docs/src/app/pages/commands/repo/repo.component.ts
@@ -63,23 +63,42 @@ import { CommonModule } from '@angular/common';
 })
 export class RepoCommandComponent {
   subcommands = [
-    { name: 'list', description: 'List repositories in a workspace' },
+    { name: 'list', description: 'List repositories in a workspace (--role, -q/--query, --sort, --page filters)' },
     { name: 'view', description: 'View repository details' },
     { name: 'clone', description: 'Clone a repository' },
-    { name: 'create', description: 'Create a new repository' },
-    { name: 'update', description: 'Update repository settings' },
+    { name: 'create', description: 'Create a new repository (--description, --public, --project, --fork-policy, --language, --issues, --wiki, --website, --main-branch)' },
+    { name: 'update', description: 'Update repository settings (--name, --description, --private/--public, --language, --fork-policy, --issues, --wiki, --website, --main-branch)' },
     { name: 'move', description: 'Move a repository to a different project in its workspace' },
     { name: 'fork', description: 'Fork a repository' },
     { name: 'delete', description: 'Delete a repository' },
-    { name: 'download', description: "Manage repository downloads (upload, list, delete artifacts)" },
+    { name: 'watchers', description: 'List users watching a repository' },
+    { name: 'forks', description: 'List forks of a repository' },
+    { name: 'download', description: 'Manage repository downloads (upload, list, get, delete)' },
+    { name: 'branch', description: 'Manage branches (list, create, view, delete)' },
+    { name: 'tag', description: 'Manage tags (list, create, view, delete)' },
+    { name: 'commit', description: 'Work with commits (list, view, diff)' },
+    { name: 'file', description: 'Browse repository files and file contents (ls, cat, history)' },
+    { name: 'webhook', description: 'Manage webhooks (list, create, view, update, delete)' },
+    { name: 'branch-restriction', description: 'Manage branch restrictions / branch permissions (list, create, delete)' },
+    { name: 'reviewer', description: 'Manage default reviewers (list, add, remove)' },
+    { name: 'permission', description: 'Inspect and manage user and group permissions (list-users, list-groups, grant-user, revoke-user, grant-group, revoke-group)' },
+    { name: 'deploy-key', description: 'Manage deploy keys (list, add, delete)' },
+    { name: 'environment', description: 'Manage deployment environments (list, create, delete)' },
+    { name: 'deployment', description: 'View deployments (list, view)' },
+    { name: 'branching-model', description: 'Manage the repository branching model (view, set)' },
   ];
 
   examples = [
     { title: 'List repositories', command: 'bitbucket repo list myworkspace' },
+    { title: 'List repositories you administer, newest first', command: 'bitbucket repo list myworkspace --role admin --sort -updated_on' },
     { title: 'View repository', command: 'bitbucket repo view myworkspace/myrepo' },
     { title: 'Clone repository', command: 'bitbucket repo clone myworkspace/myrepo' },
-    { title: 'Create repository', command: 'bitbucket repo create myworkspace myrepo --description "My new repo"' },
+    { title: 'Create repository', command: 'bitbucket repo create myworkspace myrepo --description "My new repo" --language rust --main-branch main' },
     { title: 'Update repository', command: 'bitbucket repo update myworkspace/myrepo --description "New description" --private' },
     { title: 'Move repository to a project', command: 'bitbucket repo move myworkspace/myrepo PROJ' },
+    { title: 'Create a branch from main', command: 'bitbucket repo branch create myworkspace/myrepo feature-x --from main' },
+    { title: 'Print a file at a ref', command: 'bitbucket repo file cat myworkspace/myrepo src/main.rs --ref develop' },
+    { title: 'Create a webhook', command: 'bitbucket repo webhook create myworkspace/myrepo --url https://example.com/hook --event repo:push' },
+    { title: 'Set the branching model', command: 'bitbucket repo branching-model set myworkspace/myrepo --development develop --production main' },
   ];
 }

--- a/docs/src/app/pages/commands/user/user.component.ts
+++ b/docs/src/app/pages/commands/user/user.component.ts
@@ -1,0 +1,77 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-user-command',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="max-w-4xl mx-auto px-6 py-12">
+      <!-- Page Header -->
+      <div class="mb-12">
+        <nav class="flex items-center gap-2 text-sm text-[var(--color-neutral-400)] mb-4">
+          <a routerLink="/" class="hover:text-[var(--color-bitbucket-blue)]">Docs</a>
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+          </svg>
+          <span>Commands</span>
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+          </svg>
+          <span class="text-[var(--color-neutral-700)]">user</span>
+        </nav>
+        <div class="flex items-center gap-4 mb-4">
+          <div class="w-12 h-12 bg-[var(--color-bitbucket-blue-50)] rounded-xl flex items-center justify-center text-2xl">
+            👤
+          </div>
+          <div>
+            <h1 class="text-3xl font-bold text-[var(--color-neutral-900)]">bitbucket user</h1>
+            <p class="text-[var(--color-neutral-400)]">Inspect Bitbucket user accounts</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Subcommands -->
+      <section class="mb-12">
+        <h2 class="text-xl font-semibold text-[var(--color-neutral-800)] mb-4">Subcommands</h2>
+        <div class="bg-white rounded-xl border border-[var(--color-neutral-30)] overflow-hidden">
+          @for (cmd of subcommands; track cmd.name) {
+            <div class="p-4 border-b border-[var(--color-neutral-30)] last:border-b-0">
+              <code class="text-[var(--color-bitbucket-blue)] font-mono font-medium">{{ cmd.name }}</code>
+              <p class="text-sm text-[var(--color-neutral-400)] mt-1">{{ cmd.description }}</p>
+            </div>
+          }
+        </div>
+      </section>
+
+      <!-- Examples -->
+      <section>
+        <h2 class="text-xl font-semibold text-[var(--color-neutral-800)] mb-4">Examples</h2>
+        <div class="space-y-4">
+          @for (example of examples; track example.title) {
+            <div class="bg-white rounded-xl border border-[var(--color-neutral-30)] p-6">
+              <h3 class="font-medium text-[var(--color-neutral-800)] mb-2">{{ example.title }}</h3>
+              <div class="bg-[var(--color-neutral-900)] rounded-lg p-4">
+                <code class="text-[var(--color-bitbucket-blue-light)] font-mono text-sm">{{ example.command }}</code>
+              </div>
+            </div>
+          }
+        </div>
+      </section>
+    </div>
+  `
+})
+export class UserCommandComponent {
+  subcommands = [
+    { name: 'whoami', description: 'Show the currently authenticated user' },
+    { name: 'view', description: "View a user's public profile by account ID or UUID (including braces)" },
+    { name: 'emails', description: 'List email addresses on the authenticated account' },
+  ];
+
+  examples = [
+    { title: 'Show the authenticated user', command: 'bitbucket user whoami' },
+    { title: "View a user's profile", command: 'bitbucket user view 557058:aaaa-bbbb-cccc' },
+    { title: 'List your email addresses', command: 'bitbucket user emails' },
+    { title: 'Machine-readable identity for scripts', command: 'bitbucket user whoami --output json' },
+  ];
+}

--- a/docs/src/app/pages/commands/workspace/workspace.component.ts
+++ b/docs/src/app/pages/commands/workspace/workspace.component.ts
@@ -63,10 +63,20 @@ import { CommonModule } from '@angular/common';
 })
 export class WorkspaceCommandComponent {
   subcommands = [
-    { name: 'list', description: 'List all workspaces you have access to' },
+    { name: 'list', description: 'List workspaces you have access to (--role, -q/--query, --sort, --limit; --all fetches every page)' },
+    { name: 'view', description: 'View workspace details' },
+    { name: 'members', description: 'List members of a workspace' },
+    { name: 'permissions', description: 'List user permissions on a workspace or one of its repositories (--repo)' },
+    { name: 'project', description: 'Manage projects in a workspace (list, view, create, edit, delete)' },
   ];
 
   examples = [
-    { title: 'List all workspaces', command: 'bitbucket workspace list' },
+    { title: 'List workspaces', command: 'bitbucket workspace list' },
+    { title: 'List every workspace you own', command: 'bitbucket workspace list --role owner' },
+    { title: 'View workspace details', command: 'bitbucket workspace view myworkspace' },
+    { title: 'List workspace members', command: 'bitbucket workspace members myworkspace' },
+    { title: 'List permissions on a repository', command: 'bitbucket workspace permissions myworkspace --repo myrepo' },
+    { title: 'List projects', command: 'bitbucket workspace project list myworkspace' },
+    { title: 'Create a project', command: 'bitbucket workspace project create PROJ "My Project" --workspace myworkspace' },
   ];
 }

--- a/docs/src/app/pages/configuration/configuration.component.ts
+++ b/docs/src/app/pages/configuration/configuration.component.ts
@@ -60,13 +60,17 @@ pager = true</code></pre>
           </p>
           <div class="space-y-3">
             <div>
-              <code class="text-[var(--color-bitbucket-blue)] font-mono">-w, --workspace &lt;WORKSPACE&gt;</code>
-              <p class="text-sm text-[var(--color-neutral-400)] mt-1">Override the default workspace</p>
+              <code class="text-[var(--color-bitbucket-blue)] font-mono">--workspace &lt;WORKSPACE&gt;</code>
+              <p class="text-sm text-[var(--color-neutral-400)] mt-1">Workspace to use when omitted from arguments (overrides the configured default)</p>
             </div>
             <div>
-              <code class="text-[var(--color-bitbucket-blue)] font-mono">-r, --repo &lt;REPO&gt;</code>
-              <p class="text-sm text-[var(--color-neutral-400)] mt-1">Override the repository</p>
+              <code class="text-[var(--color-bitbucket-blue)] font-mono">--output &lt;table|json&gt;</code>
+              <p class="text-sm text-[var(--color-neutral-400)] mt-1">Output format for command results. The default, table, prints human-readable tables; json emits raw pretty-printed JSON for piping into jq or scripts</p>
             </div>
+          </div>
+          <div class="bg-[var(--color-neutral-900)] rounded-lg p-4 mt-4">
+            <pre class="text-sm text-[var(--color-neutral-100)] font-mono overflow-x-auto"><code># IDs and titles of open pull requests
+bitbucket pr list myworkspace/myrepo --output json | jq -r '.[] | "\\(.id)\\t\\(.title)"'</code></pre>
           </div>
         </div>
       </section>
@@ -78,7 +82,5 @@ export class ConfigurationComponent {
     { key: 'auth.username', description: 'Your Bitbucket username (set automatically on login)', default: 'none' },
     { key: 'auth.default_workspace', description: 'Default workspace for commands', default: 'none' },
     { key: 'defaults.workspace', description: 'Legacy fallback for the default workspace; auth.default_workspace takes precedence', default: 'none' },
-    { key: 'display.color', description: 'Enable colored output', default: 'true' },
-    { key: 'display.pager', description: 'Use pager for long output', default: 'true' },
   ];
 }

--- a/docs/src/app/pages/home/home.component.ts
+++ b/docs/src/app/pages/home/home.component.ts
@@ -5,7 +5,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import {
   faFolder, faCodeBranch, faBug, faBolt, faBuilding, faTerminal, faShieldAlt,
-  faArrowRight, faCopy, faChevronRight, faKey
+  faArrowRight, faCopy, faChevronRight, faKey, faUser
 } from '@fortawesome/free-solid-svg-icons';
 import { faGithub, faBitbucket } from '@fortawesome/free-brands-svg-icons';
 
@@ -177,7 +177,8 @@ export class HomeComponent {
     { name: 'pr', path: '/commands/pr', icon: faCodeBranch, description: 'Manage pull requests' },
     { name: 'issue', path: '/commands/issue', icon: faBug, description: 'Manage issues' },
     { name: 'pipeline', path: '/commands/pipeline', icon: faBolt, description: 'Manage pipelines' },
-    { name: 'workspace', path: '/commands/workspace', icon: faBuilding, description: 'Manage workspaces' },
+    { name: 'workspace', path: '/commands/workspace', icon: faBuilding, description: 'Manage workspaces and their projects' },
+    { name: 'user', path: '/commands/user', icon: faUser, description: 'Inspect Bitbucket user accounts' },
     { name: 'tui', path: '/tui', icon: faTerminal, description: 'Launch the interactive terminal UI' },
   ];
 

--- a/docs/src/app/pages/installation/installation.component.ts
+++ b/docs/src/app/pages/installation/installation.component.ts
@@ -116,7 +116,7 @@ import { CommonModule } from '@angular/common';
             <code class="text-[var(--color-bitbucket-blue-light)] font-mono">bitbucket --version</code>
           </div>
           <p class="text-[var(--color-neutral-400)] text-sm">
-            You should see output like: <code class="bg-[var(--color-neutral-20)] px-2 py-0.5 rounded text-[var(--color-neutral-700)]">bitbucket 0.4.0</code>
+            You should see output like: <code class="bg-[var(--color-neutral-20)] px-2 py-0.5 rounded text-[var(--color-neutral-700)]">bitbucket 1.0.0</code>
           </p>
         </div>
       </section>

--- a/docs/src/main.ts
+++ b/docs/src/main.ts
@@ -1,13 +1,6 @@
 import { bootstrapApplication } from '@angular/platform-browser';
-import { appConfig, setupFontAwesome } from './app/app.config';
+import { appConfig } from './app/app.config';
 import { App } from './app/app';
-import { FaConfig, FaIconLibrary } from '@fortawesome/angular-fontawesome';
 
 bootstrapApplication(App, appConfig)
-  .then((appRef) => {
-    // Setup FontAwesome after bootstrap
-    const library = appRef.injector.get(FaIconLibrary);
-    const config = appRef.injector.get(FaConfig);
-    setupFontAwesome(library, config);
-  })
   .catch((err) => console.error(err));

--- a/packaging/alpine/APKBUILD
+++ b/packaging/alpine/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Pegasus Heavy Industries
 # Maintainer: Pegasus Heavy Industries
 pkgname=bitbucket-cli
-pkgver=0.4.0
+pkgver=1.0.0
 pkgrel=0
 pkgdesc="A powerful command-line interface for Bitbucket Cloud"
 url="https://github.com/pegasusheavy/bitbucket-cli"

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Pegasus Heavy Industries
 pkgname=bitbucket-cli
-pkgver=0.4.0
+pkgver=1.0.0
 pkgrel=1
 pkgdesc="A powerful command-line interface for Bitbucket Cloud"
 arch=('x86_64' 'aarch64')

--- a/packaging/windows/main.wxs
+++ b/packaging/windows/main.wxs
@@ -5,7 +5,7 @@
     <Package
         Name="Bitbucket CLI"
         Manufacturer="Pegasus Heavy Industries"
-        Version="0.4.0"
+        Version="1.0.0"
         UpgradeCode="12345678-1234-1234-1234-123456789012"
         Scope="perMachine"
         InstallerVersion="450"

--- a/src/api/branch_restrictions.rs
+++ b/src/api/branch_restrictions.rs
@@ -1,0 +1,69 @@
+use anyhow::Result;
+
+use super::BitbucketClient;
+use crate::models::{BranchRestriction, Paginated};
+
+impl BitbucketClient {
+    /// List branch restriction rules on a repository
+    pub async fn list_branch_restrictions(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<BranchRestriction>> {
+        let path = format!(
+            "/repositories/{}/{}/branch-restrictions",
+            workspace, repo_slug
+        );
+
+        match pagelen {
+            Some(len) => {
+                self.get_with_query(&path, &[("pagelen", len.to_string().as_str())])
+                    .await
+            }
+            None => self.get(&path).await,
+        }
+    }
+
+    /// Create a branch restriction rule.
+    ///
+    /// `value` is the numeric parameter required by some kinds (e.g. the
+    /// approval count for `require_approvals_to_merge`); it is omitted from
+    /// the request body when `None`.
+    pub async fn create_branch_restriction(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        kind: &str,
+        pattern: &str,
+        value: Option<u64>,
+    ) -> Result<BranchRestriction> {
+        let mut body = serde_json::json!({
+            "kind": kind,
+            "pattern": pattern,
+        });
+        if let Some(value) = value {
+            body["value"] = serde_json::json!(value);
+        }
+
+        let path = format!(
+            "/repositories/{}/{}/branch-restrictions",
+            workspace, repo_slug
+        );
+        self.post(&path, &body).await
+    }
+
+    /// Delete a branch restriction rule by id
+    pub async fn delete_branch_restriction(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        id: u64,
+    ) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/branch-restrictions/{}",
+            workspace, repo_slug, id
+        );
+        self.delete(&path).await
+    }
+}

--- a/src/api/branching_model.rs
+++ b/src/api/branching_model.rs
@@ -1,0 +1,30 @@
+use anyhow::Result;
+
+use super::BitbucketClient;
+use crate::models::{BranchingModel, UpdateBranchingModelRequest};
+
+impl BitbucketClient {
+    /// Get a repository's effective branching model
+    pub async fn get_branching_model(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+    ) -> Result<BranchingModel> {
+        let path = format!("/repositories/{}/{}/branching-model", workspace, repo_slug);
+        self.get(&path).await
+    }
+
+    /// Update a repository's branching model settings
+    pub async fn update_branching_model_settings(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        request: &UpdateBranchingModelRequest,
+    ) -> Result<BranchingModel> {
+        let path = format!(
+            "/repositories/{}/{}/branching-model/settings",
+            workspace, repo_slug
+        );
+        self.put(&path, request).await
+    }
+}

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -7,6 +7,9 @@ use crate::models::Paginated;
 
 const API_BASE_URL: &str = "https://api.bitbucket.org/2.0";
 
+/// User-Agent header sent with every request, versioned from Cargo metadata.
+pub(crate) const USER_AGENT: &str = concat!("bitbucket-cli/", env!("CARGO_PKG_VERSION"));
+
 /// Bitbucket API client
 #[derive(Clone)]
 pub struct BitbucketClient {
@@ -18,18 +21,13 @@ impl BitbucketClient {
     /// Create a new authenticated client
     pub fn new(credential: Credential) -> Result<Self> {
         let client = Client::builder()
-            .user_agent("bitbucket-cli")
+            .user_agent(USER_AGENT)
             .timeout(std::time::Duration::from_secs(30))
             .connect_timeout(std::time::Duration::from_secs(10))
             .build()
             .context("Failed to create HTTP client")?;
 
         Ok(Self { client, credential })
-    }
-
-    /// Get the authorization header value
-    pub fn auth_header(&self) -> String {
-        self.credential.auth_header()
     }
 
     /// Create a client from stored credentials, automatically refreshing if needed
@@ -65,11 +63,6 @@ impl BitbucketClient {
         };
 
         Self::new(credential)
-    }
-
-    /// Get the base API URL
-    pub fn base_url(&self) -> &str {
-        API_BASE_URL
     }
 
     /// Build a URL for an API endpoint
@@ -138,6 +131,28 @@ impl BitbucketClient {
         if status.is_success() {
             response
                 .text()
+                .await
+                .context("Failed to read response body")
+        } else {
+            self.handle_error(status, response).await
+        }
+    }
+
+    /// Make a GET request that returns the raw response body as bytes
+    pub(crate) async fn get_bytes(&self, path: &str) -> Result<bytes::Bytes> {
+        let response = self
+            .client
+            .get(self.url(path))
+            .header("Authorization", self.credential.auth_header())
+            .send()
+            .await
+            .context("Request failed")?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            response
+                .bytes()
                 .await
                 .context("Failed to read response body")
         } else {

--- a/src/api/commits.rs
+++ b/src/api/commits.rs
@@ -1,0 +1,71 @@
+use anyhow::Result;
+
+use super::BitbucketClient;
+use crate::api::util::urlencode_segment;
+use crate::models::{CommitSummary, Paginated};
+
+impl BitbucketClient {
+    /// List commits in a repository, newest first.
+    ///
+    /// With `revision` set, lists the history reachable from that branch,
+    /// tag, or commit hash; otherwise lists from the default branch.
+    pub async fn list_commits(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        revision: Option<&str>,
+        page: Option<u32>,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<CommitSummary>> {
+        let path = match revision {
+            Some(rev) => format!(
+                "/repositories/{}/{}/commits/{}",
+                workspace,
+                repo_slug,
+                urlencode_segment(rev)
+            ),
+            None => format!("/repositories/{}/{}/commits", workspace, repo_slug),
+        };
+
+        let mut params = Vec::new();
+        if let Some(p) = page {
+            params.push(("page", p.to_string()));
+        }
+        if let Some(len) = pagelen {
+            params.push(("pagelen", len.to_string()));
+        }
+
+        let param_refs: Vec<(&str, &str)> = params.iter().map(|(k, v)| (*k, v.as_str())).collect();
+        self.get_with_query(&path, &param_refs).await
+    }
+
+    /// Get a single commit by hash.
+    pub async fn get_commit(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        hash: &str,
+    ) -> Result<CommitSummary> {
+        let path = format!(
+            "/repositories/{}/{}/commit/{}",
+            workspace,
+            repo_slug,
+            urlencode_segment(hash)
+        );
+        self.get(&path).await
+    }
+
+    /// Get a raw unified diff for a commit or revision spec.
+    ///
+    /// `spec` is either a single revision (diff against its first parent) or
+    /// a `source..destination` pair of revisions.
+    pub async fn get_diff(&self, workspace: &str, repo_slug: &str, spec: &str) -> Result<String> {
+        let path = format!(
+            "/repositories/{}/{}/diff/{}",
+            workspace,
+            repo_slug,
+            urlencode_segment(spec)
+        );
+        self.get_text(&path, None).await
+    }
+}

--- a/src/api/default_reviewers.rs
+++ b/src/api/default_reviewers.rs
@@ -1,0 +1,64 @@
+use anyhow::Result;
+
+use super::BitbucketClient;
+use super::webhooks::encode_path_segment;
+use crate::models::{Paginated, User};
+
+impl BitbucketClient {
+    /// List a repository's default reviewers
+    pub async fn list_default_reviewers(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<User>> {
+        let path = format!(
+            "/repositories/{}/{}/default-reviewers",
+            workspace, repo_slug
+        );
+
+        match pagelen {
+            Some(len) => {
+                self.get_with_query(&path, &[("pagelen", len.to_string().as_str())])
+                    .await
+            }
+            None => self.get(&path).await,
+        }
+    }
+
+    /// Add a user to a repository's default reviewers.
+    ///
+    /// `username` may be a username, an account ID, or a brace-wrapped UUID.
+    /// The endpoint is a bodyless PUT; an empty JSON object is sent because
+    /// the client's PUT helper always attaches a JSON body.
+    pub async fn add_default_reviewer(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        username: &str,
+    ) -> Result<User> {
+        let path = format!(
+            "/repositories/{}/{}/default-reviewers/{}",
+            workspace,
+            repo_slug,
+            encode_path_segment(username)
+        );
+        self.put(&path, &serde_json::json!({})).await
+    }
+
+    /// Remove a user from a repository's default reviewers
+    pub async fn remove_default_reviewer(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        username: &str,
+    ) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/default-reviewers/{}",
+            workspace,
+            repo_slug,
+            encode_path_segment(username)
+        );
+        self.delete(&path).await
+    }
+}

--- a/src/api/deploy.rs
+++ b/src/api/deploy.rs
@@ -1,0 +1,123 @@
+use anyhow::Result;
+
+use super::BitbucketClient;
+use crate::models::{
+    AddDeployKeyRequest, CreateEnvironmentRequest, DeployKey, Deployment, Environment, Paginated,
+};
+
+impl BitbucketClient {
+    // -----------------------------------------------------------------------
+    // Deploy keys
+    // -----------------------------------------------------------------------
+
+    /// List deploy keys for a repository
+    pub async fn list_deploy_keys(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+    ) -> Result<Paginated<DeployKey>> {
+        let path = format!("/repositories/{}/{}/deploy-keys", workspace, repo_slug);
+        self.get(&path).await
+    }
+
+    /// Add a deploy key to a repository
+    pub async fn add_deploy_key(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        request: &AddDeployKeyRequest,
+    ) -> Result<DeployKey> {
+        let path = format!("/repositories/{}/{}/deploy-keys", workspace, repo_slug);
+        self.post(&path, request).await
+    }
+
+    /// Delete a deploy key from a repository
+    pub async fn delete_deploy_key(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        key_id: u64,
+    ) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/deploy-keys/{}",
+            workspace, repo_slug, key_id
+        );
+        self.delete(&path).await
+    }
+
+    // -----------------------------------------------------------------------
+    // Deployment environments
+    // -----------------------------------------------------------------------
+
+    /// List deployment environments for a repository
+    pub async fn list_environments(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+    ) -> Result<Paginated<Environment>> {
+        let path = format!("/repositories/{}/{}/environments/", workspace, repo_slug);
+        self.get(&path).await
+    }
+
+    /// Create a deployment environment
+    pub async fn create_environment(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        request: &CreateEnvironmentRequest,
+    ) -> Result<Environment> {
+        let path = format!("/repositories/{}/{}/environments/", workspace, repo_slug);
+        self.post(&path, request).await
+    }
+
+    /// Delete a deployment environment
+    pub async fn delete_environment(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        environment_uuid: &str,
+    ) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/environments/{}",
+            workspace, repo_slug, environment_uuid
+        );
+        self.delete(&path).await
+    }
+
+    // -----------------------------------------------------------------------
+    // Deployments
+    // -----------------------------------------------------------------------
+
+    /// List deployments for a repository
+    pub async fn list_deployments(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<Deployment>> {
+        let mut query = Vec::new();
+
+        if let Some(len) = pagelen {
+            query.push(("pagelen", len.to_string()));
+        }
+
+        let query_refs: Vec<(&str, &str)> = query.iter().map(|(k, v)| (*k, v.as_str())).collect();
+
+        let path = format!("/repositories/{}/{}/deployments/", workspace, repo_slug);
+        self.get_with_query(&path, &query_refs).await
+    }
+
+    /// Get a specific deployment
+    pub async fn get_deployment(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        deployment_uuid: &str,
+    ) -> Result<Deployment> {
+        let path = format!(
+            "/repositories/{}/{}/deployments/{}",
+            workspace, repo_slug, deployment_uuid
+        );
+        self.get(&path).await
+    }
+}

--- a/src/api/downloads.rs
+++ b/src/api/downloads.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use reqwest::multipart::{Form, Part};
 
 use super::BitbucketClient;
+use crate::api::util::urlencode_segment;
 use crate::models::Download;
 
 impl BitbucketClient {
@@ -40,6 +41,22 @@ impl BitbucketClient {
         self.get_all_pages::<Download>(&path).await
     }
 
+    /// Fetch a single artifact's raw bytes from a repository's downloads area.
+    pub async fn get_download(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        name: &str,
+    ) -> Result<bytes::Bytes> {
+        let path = format!(
+            "/repositories/{}/{}/downloads/{}",
+            workspace,
+            repo_slug,
+            urlencode_segment(name)
+        );
+        self.get_bytes(&path).await
+    }
+
     /// Delete a single artifact from a repository's downloads area.
     pub async fn delete_download(
         &self,
@@ -68,21 +85,6 @@ pub fn download_url(workspace: &str, repo_slug: &str, name: &str) -> String {
         repo_slug,
         urlencode_segment(name)
     )
-}
-
-/// Percent-encode the characters that are unsafe in a single URL path segment.
-/// Intentionally minimal — file names are mostly `[A-Za-z0-9._-]` plus spaces.
-fn urlencode_segment(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for b in s.bytes() {
-        match b {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                out.push(b as char)
-            }
-            _ => out.push_str(&format!("%{:02X}", b)),
-        }
-    }
-    out
 }
 
 #[cfg(test)]

--- a/src/api/issues.rs
+++ b/src/api/issues.rs
@@ -1,9 +1,59 @@
-use anyhow::Result;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use reqwest::multipart::{Form, Part};
 
 use super::BitbucketClient;
+use crate::api::util::urlencode_segment;
 use crate::models::{
-    CreateIssueCommentRequest, CreateIssueRequest, Issue, IssueComment, IssueState, Paginated,
+    CreateIssueCommentRequest, CreateIssueRequest, Issue, IssueAttachment, IssueChange,
+    IssueComment, IssueContentRequest, IssueKind, IssueMetaItem, IssuePriority, IssueState,
+    Paginated, UserAccountId,
 };
+
+/// Fields of an issue that can be changed with
+/// [`BitbucketClient::update_issue_full`]. Unset fields are left untouched.
+#[derive(Default)]
+pub struct IssueUpdate<'a> {
+    pub title: Option<&'a str>,
+    /// Raw markdown body for the issue description.
+    pub content: Option<&'a str>,
+    pub kind: Option<IssueKind>,
+    pub priority: Option<IssuePriority>,
+    /// Atlassian account id of the new assignee.
+    pub assignee: Option<&'a str>,
+    pub state: Option<IssueState>,
+}
+
+impl IssueUpdate<'_> {
+    /// True when no field is set, i.e. the update would be a no-op.
+    pub fn is_empty(&self) -> bool {
+        self.title.is_none()
+            && self.content.is_none()
+            && self.kind.is_none()
+            && self.priority.is_none()
+            && self.assignee.is_none()
+            && self.state.is_none()
+    }
+}
+
+/// Filters and paging options for [`BitbucketClient::list_issues_filtered`].
+#[derive(Default)]
+pub(crate) struct IssueListFilters<'a> {
+    pub state: Option<IssueState>,
+    pub kind: Option<IssueKind>,
+    pub priority: Option<IssuePriority>,
+    /// Atlassian account id of the assignee to filter by.
+    pub assignee: Option<&'a str>,
+    /// Atlassian account id of the reporter to filter by.
+    pub reporter: Option<&'a str>,
+    /// Raw BBQL query; when set it wins over the individual filters above.
+    pub query: Option<&'a str>,
+    /// Sort field, e.g. `-updated_on` for most recently updated first.
+    pub sort: Option<&'a str>,
+    pub page: Option<u32>,
+    pub pagelen: Option<u32>,
+}
 
 impl BitbucketClient {
     /// List issues for a repository
@@ -15,7 +65,28 @@ impl BitbucketClient {
         page: Option<u32>,
         pagelen: Option<u32>,
     ) -> Result<Paginated<Issue>> {
-        let query = issue_list_query(state, page, pagelen);
+        self.list_issues_filtered(
+            workspace,
+            repo_slug,
+            &IssueListFilters {
+                state,
+                page,
+                pagelen,
+                ..Default::default()
+            },
+        )
+        .await
+    }
+
+    /// List issues for a repository with the full set of filters, an optional
+    /// raw BBQL query, and sorting.
+    pub(crate) async fn list_issues_filtered(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        filters: &IssueListFilters<'_>,
+    ) -> Result<Paginated<Issue>> {
+        let query = issue_list_query_full(filters);
         let query_refs: Vec<(&str, &str)> = query.iter().map(|(k, v)| (*k, v.as_str())).collect();
 
         let path = format!("/repositories/{}/{}/issues", workspace, repo_slug);
@@ -47,7 +118,10 @@ impl BitbucketClient {
         self.post(&path, request).await
     }
 
-    /// Update an issue
+    /// Update an issue's title, description and/or state.
+    ///
+    /// Convenience wrapper over [`Self::update_issue_full`] kept for the
+    /// existing close/reopen callers.
     pub async fn update_issue(
         &self,
         workspace: &str,
@@ -57,25 +131,56 @@ impl BitbucketClient {
         content: Option<&str>,
         state: Option<IssueState>,
     ) -> Result<Issue> {
-        #[derive(serde::Serialize)]
-        struct UpdateRequest {
-            #[serde(skip_serializing_if = "Option::is_none")]
-            title: Option<String>,
-            #[serde(skip_serializing_if = "Option::is_none")]
-            content: Option<ContentRequest>,
-            #[serde(skip_serializing_if = "Option::is_none")]
-            state: Option<IssueState>,
-        }
+        self.update_issue_full(
+            workspace,
+            repo_slug,
+            issue_id,
+            &IssueUpdate {
+                title,
+                content,
+                state,
+                ..Default::default()
+            },
+        )
+        .await
+    }
 
+    /// Update any combination of an issue's editable fields; unset fields are
+    /// omitted from the request body and left unchanged server-side.
+    pub async fn update_issue_full(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        issue_id: u64,
+        update: &IssueUpdate<'_>,
+    ) -> Result<Issue> {
         #[derive(serde::Serialize)]
-        struct ContentRequest {
-            raw: String,
+        struct UpdateRequest<'a> {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            title: Option<&'a str>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            content: Option<IssueContentRequest>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            kind: Option<&'a IssueKind>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            priority: Option<&'a IssuePriority>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            assignee: Option<UserAccountId>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            state: Option<&'a IssueState>,
         }
 
         let request = UpdateRequest {
-            title: title.map(|t| t.to_string()),
-            content: content.map(|c| ContentRequest { raw: c.to_string() }),
-            state,
+            title: update.title,
+            content: update
+                .content
+                .map(|c| IssueContentRequest { raw: c.to_string() }),
+            kind: update.kind.as_ref(),
+            priority: update.priority.as_ref(),
+            assignee: update.assignee.map(|a| UserAccountId {
+                account_id: a.to_string(),
+            }),
+            state: update.state.as_ref(),
         };
 
         let path = format!(
@@ -105,12 +210,19 @@ impl BitbucketClient {
         workspace: &str,
         repo_slug: &str,
         issue_id: u64,
+        pagelen: Option<u32>,
     ) -> Result<Paginated<IssueComment>> {
+        let query: Vec<(&str, String)> = pagelen
+            .map(|len| ("pagelen", len.to_string()))
+            .into_iter()
+            .collect();
+        let query_refs: Vec<(&str, &str)> = query.iter().map(|(k, v)| (*k, v.as_str())).collect();
+
         let path = format!(
             "/repositories/{}/{}/issues/{}/comments",
             workspace, repo_slug, issue_id
         );
-        self.get(&path).await
+        self.get_with_query(&path, &query_refs).await
     }
 
     /// Add a comment to an issue
@@ -122,7 +234,7 @@ impl BitbucketClient {
         content: &str,
     ) -> Result<IssueComment> {
         let request = CreateIssueCommentRequest {
-            content: crate::models::IssueContentRequest {
+            content: IssueContentRequest {
                 raw: content.to_string(),
             },
         };
@@ -132,6 +244,162 @@ impl BitbucketClient {
             workspace, repo_slug, issue_id
         );
         self.post(&path, &request).await
+    }
+
+    /// Update the body of an existing comment on an issue.
+    pub async fn update_issue_comment(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        issue_id: u64,
+        comment_id: u64,
+        content: &str,
+    ) -> Result<IssueComment> {
+        let request = CreateIssueCommentRequest {
+            content: IssueContentRequest {
+                raw: content.to_string(),
+            },
+        };
+
+        let path = format!(
+            "/repositories/{}/{}/issues/{}/comments/{}",
+            workspace, repo_slug, issue_id, comment_id
+        );
+        self.put(&path, &request).await
+    }
+
+    /// Delete a comment from an issue.
+    pub async fn delete_issue_comment(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        issue_id: u64,
+        comment_id: u64,
+    ) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/issues/{}/comments/{}",
+            workspace, repo_slug, issue_id, comment_id
+        );
+        self.delete(&path).await
+    }
+
+    /// List entries from an issue's change log (state transitions,
+    /// reassignments, ...).
+    pub async fn list_issue_changes(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        issue_id: u64,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<IssueChange>> {
+        let query: Vec<(&str, String)> = pagelen
+            .map(|len| ("pagelen", len.to_string()))
+            .into_iter()
+            .collect();
+        let query_refs: Vec<(&str, &str)> = query.iter().map(|(k, v)| (*k, v.as_str())).collect();
+
+        let path = format!(
+            "/repositories/{}/{}/issues/{}/changes",
+            workspace, repo_slug, issue_id
+        );
+        self.get_with_query(&path, &query_refs).await
+    }
+
+    /// List the components defined in a repository's issue tracker,
+    /// following pagination until every page has been fetched.
+    pub async fn list_issue_components(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+    ) -> Result<Vec<IssueMetaItem>> {
+        let path = format!("/repositories/{}/{}/components", workspace, repo_slug);
+        self.get_all_pages::<IssueMetaItem>(&path).await
+    }
+
+    /// List the milestones defined in a repository's issue tracker,
+    /// following pagination until every page has been fetched.
+    pub async fn list_issue_milestones(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+    ) -> Result<Vec<IssueMetaItem>> {
+        let path = format!("/repositories/{}/{}/milestones", workspace, repo_slug);
+        self.get_all_pages::<IssueMetaItem>(&path).await
+    }
+
+    /// List the versions defined in a repository's issue tracker,
+    /// following pagination until every page has been fetched.
+    pub async fn list_issue_versions(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+    ) -> Result<Vec<IssueMetaItem>> {
+        let path = format!("/repositories/{}/{}/versions", workspace, repo_slug);
+        self.get_all_pages::<IssueMetaItem>(&path).await
+    }
+
+    /// List the files attached to an issue, following pagination until every
+    /// page has been fetched.
+    pub async fn list_issue_attachments(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        issue_id: u64,
+    ) -> Result<Vec<IssueAttachment>> {
+        let path = format!(
+            "/repositories/{}/{}/issues/{}/attachments",
+            workspace, repo_slug, issue_id
+        );
+        self.get_all_pages::<IssueAttachment>(&path).await
+    }
+
+    /// Attach one or more files to an issue via a multipart upload.
+    ///
+    /// Follows the repository downloads upload convention: every file goes
+    /// under the "files" form field, keyed server-side by filename.
+    pub async fn upload_issue_attachments(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        issue_id: u64,
+        files: &[(String, PathBuf)],
+    ) -> Result<()> {
+        let mut form = Form::new();
+
+        for (upload_name, path) in files {
+            // Bodies are buffered in memory, matching upload_downloads:
+            // streaming would require the reqwest `stream` feature +
+            // tokio-util; acceptable for CLI-sized attachments.
+            let bytes = std::fs::read(path)
+                .with_context(|| format!("Failed to read file '{}'", path.display()))?;
+            let part = Part::bytes(bytes).file_name(upload_name.clone());
+            form = form.part("files", part);
+        }
+
+        let path = format!(
+            "/repositories/{}/{}/issues/{}/attachments",
+            workspace, repo_slug, issue_id
+        );
+        self.post_multipart(&path, form).await
+    }
+
+    /// Delete an attachment from an issue by its path (usually the filename
+    /// as returned by the attachments list).
+    pub async fn delete_issue_attachment(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        issue_id: u64,
+        attachment_path: &str,
+    ) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/issues/{}/attachments/{}",
+            workspace,
+            repo_slug,
+            issue_id,
+            urlencode_segment(attachment_path)
+        );
+        self.delete(&path).await
     }
 
     /// Vote for an issue
@@ -187,32 +455,113 @@ impl BitbucketClient {
 
 /// Build the query parameters for listing issues.
 ///
-/// The state filter is expressed as a BBQL `q` parameter with the state
-/// value quoted, since some states (e.g. "on hold") contain spaces.
+/// Kept with its original three-argument shape so the original tests keep
+/// covering the delegation path; the full builder lives in
+/// [`issue_list_query_full`], which production code reaches through
+/// [`BitbucketClient::list_issues_filtered`].
+#[cfg(test)]
 fn issue_list_query(
     state: Option<IssueState>,
     page: Option<u32>,
     pagelen: Option<u32>,
 ) -> Vec<(&'static str, String)> {
+    issue_list_query_full(&IssueListFilters {
+        state,
+        page,
+        pagelen,
+        ..Default::default()
+    })
+}
+
+/// Build the full set of query parameters for listing issues.
+///
+/// A raw BBQL `query` wins over the individual filters; otherwise the
+/// filters are AND-ed together into a single `q` expression.
+fn issue_list_query_full(filters: &IssueListFilters<'_>) -> Vec<(&'static str, String)> {
     let mut query = Vec::new();
 
-    if let Some(s) = state {
-        query.push(("q", format!("state=\"{}\"", s)));
+    let q = match filters.query {
+        Some(raw) => Some(raw.to_string()),
+        None => issue_query_filter(
+            filters.state.as_ref(),
+            filters.kind.as_ref(),
+            filters.priority.as_ref(),
+            filters.assignee,
+            filters.reporter,
+        ),
+    };
+
+    if let Some(q) = q {
+        query.push(("q", q));
     }
-    if let Some(p) = page {
+    if let Some(sort) = filters.sort {
+        query.push(("sort", sort.to_string()));
+    }
+    if let Some(p) = filters.page {
         query.push(("page", p.to_string()));
     }
-    if let Some(len) = pagelen {
+    if let Some(len) = filters.pagelen {
         query.push(("pagelen", len.to_string()));
     }
 
     query
 }
 
+/// Combine individual issue filters into a single BBQL `q` expression, or
+/// `None` when no filter is set.
+///
+/// Every value is quoted, since some states (e.g. "on hold") contain spaces.
+/// Assignee and reporter filter on `*.account_id`, matching the account ids
+/// the rest of the CLI accepts.
+fn issue_query_filter(
+    state: Option<&IssueState>,
+    kind: Option<&IssueKind>,
+    priority: Option<&IssuePriority>,
+    assignee: Option<&str>,
+    reporter: Option<&str>,
+) -> Option<String> {
+    let mut parts = Vec::new();
+
+    if let Some(s) = state {
+        parts.push(format!("state=\"{}\"", s));
+    }
+    if let Some(k) = kind {
+        parts.push(format!("kind=\"{}\"", k));
+    }
+    if let Some(p) = priority {
+        parts.push(format!("priority=\"{}\"", p));
+    }
+    if let Some(a) = assignee {
+        parts.push(format!("assignee.account_id={}", bbql_quote(a)));
+    }
+    if let Some(r) = reporter {
+        parts.push(format!("reporter.account_id={}", bbql_quote(r)));
+    }
+
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(" AND "))
+    }
+}
+
+/// Quote a free-text value for use inside a BBQL `q=` expression: wrap it in
+/// double quotes, backslash-escaping any `\` (first) then any `"` so the value
+/// cannot break out of the quoted string and inject BBQL. Used for
+/// user-supplied `--assignee`/`--reporter` values; state/kind/priority come
+/// from enums and are already safe.
+fn bbql_quote(s: &str) -> String {
+    let escaped = s.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{}\"", escaped)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::issue_list_query;
-    use crate::models::IssueState;
+    use super::{
+        IssueListFilters, bbql_quote, issue_list_query, issue_list_query_full, issue_query_filter,
+        urlencode_segment,
+    };
+    use crate::models::{IssueKind, IssuePriority, IssueState};
 
     #[test]
     fn open_state_builds_quoted_bbql_filter() {
@@ -254,5 +603,102 @@ mod tests {
                 ("pagelen", "25".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn query_filter_is_none_without_filters() {
+        assert_eq!(issue_query_filter(None, None, None, None, None), None);
+    }
+
+    #[test]
+    fn query_filter_quotes_on_hold_state() {
+        assert_eq!(
+            issue_query_filter(Some(&IssueState::OnHold), None, None, None, None).as_deref(),
+            Some("state=\"on hold\"")
+        );
+    }
+
+    #[test]
+    fn query_filter_ands_all_filters_in_order() {
+        assert_eq!(
+            issue_query_filter(
+                Some(&IssueState::Open),
+                Some(&IssueKind::Bug),
+                Some(&IssuePriority::Major),
+                Some("acc-123"),
+                Some("acc-456"),
+            )
+            .as_deref(),
+            Some(
+                "state=\"open\" AND kind=\"bug\" AND priority=\"major\" AND \
+                 assignee.account_id=\"acc-123\" AND reporter.account_id=\"acc-456\""
+            )
+        );
+    }
+
+    #[test]
+    fn query_filter_handles_people_filters_alone() {
+        assert_eq!(
+            issue_query_filter(None, None, None, Some("acc-123"), None).as_deref(),
+            Some("assignee.account_id=\"acc-123\"")
+        );
+        assert_eq!(
+            issue_query_filter(None, None, None, None, Some("acc-456")).as_deref(),
+            Some("reporter.account_id=\"acc-456\"")
+        );
+    }
+
+    #[test]
+    fn full_query_raw_query_wins_over_filters() {
+        let filters = IssueListFilters {
+            state: Some(IssueState::Open),
+            kind: Some(IssueKind::Bug),
+            query: Some("kind=\"task\""),
+            ..Default::default()
+        };
+        assert_eq!(
+            issue_list_query_full(&filters),
+            vec![("q", "kind=\"task\"".to_string())]
+        );
+    }
+
+    #[test]
+    fn full_query_includes_sort_page_and_pagelen_in_order() {
+        let filters = IssueListFilters {
+            state: Some(IssueState::Open),
+            sort: Some("-updated_on"),
+            page: Some(2),
+            pagelen: Some(50),
+            ..Default::default()
+        };
+        assert_eq!(
+            issue_list_query_full(&filters),
+            vec![
+                ("q", "state=\"open\"".to_string()),
+                ("sort", "-updated_on".to_string()),
+                ("page", "2".to_string()),
+                ("pagelen", "50".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn bbql_quote_escapes_backslash_and_double_quote() {
+        // A value with both a `"` (would close the string) and a `\` (would
+        // escape the next char) must come back fully escaped and wrapped.
+        assert_eq!(bbql_quote(r#"a"b\c"#), r#""a\"b\\c""#);
+        // A plain value is just wrapped in quotes.
+        assert_eq!(bbql_quote("acc-123"), r#""acc-123""#);
+        // An injection attempt cannot break out of the quoted string.
+        assert_eq!(
+            bbql_quote(r#"x" OR state="open"#),
+            r#""x\" OR state=\"open""#
+        );
+    }
+
+    #[test]
+    fn urlencode_encodes_spaces_and_leaves_safe_chars() {
+        assert_eq!(urlencode_segment("shot 1.png"), "shot%201.png");
+        assert_eq!(urlencode_segment("a-b_c.d~1"), "a-b_c.d~1");
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,9 +1,21 @@
+pub mod branch_restrictions;
+pub mod branching_model;
 pub mod client;
+pub mod commits;
+pub mod default_reviewers;
+pub mod deploy;
 pub mod downloads;
 pub mod issues;
+pub mod permissions;
 pub mod pipelines;
+pub mod projects;
 pub mod pullrequests;
+pub mod refs;
 pub mod repos;
+pub mod source;
+pub mod users;
+pub mod util;
+pub mod webhooks;
 pub mod workspaces;
 
 pub use client::*;

--- a/src/api/permissions.rs
+++ b/src/api/permissions.rs
@@ -1,0 +1,123 @@
+use anyhow::Result;
+
+use super::BitbucketClient;
+use super::webhooks::encode_path_segment;
+use crate::models::{GroupPermission, Paginated, UserPermission};
+
+impl BitbucketClient {
+    /// List users with explicit permissions on a repository
+    pub async fn list_user_permissions(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<UserPermission>> {
+        let path = format!(
+            "/repositories/{}/{}/permissions-config/users",
+            workspace, repo_slug
+        );
+
+        match pagelen {
+            Some(len) => {
+                self.get_with_query(&path, &[("pagelen", len.to_string().as_str())])
+                    .await
+            }
+            None => self.get(&path).await,
+        }
+    }
+
+    /// List groups with explicit permissions on a repository
+    pub async fn list_group_permissions(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<GroupPermission>> {
+        let path = format!(
+            "/repositories/{}/{}/permissions-config/groups",
+            workspace, repo_slug
+        );
+
+        match pagelen {
+            Some(len) => {
+                self.get_with_query(&path, &[("pagelen", len.to_string().as_str())])
+                    .await
+            }
+            None => self.get(&path).await,
+        }
+    }
+
+    /// Grant or update a user's explicit permission on a repository.
+    ///
+    /// `selected_user` may be an account ID or a brace-wrapped UUID;
+    /// `permission` is `read`, `write`, or `admin`.
+    pub async fn grant_user_permission(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        selected_user: &str,
+        permission: &str,
+    ) -> Result<UserPermission> {
+        let path = format!(
+            "/repositories/{}/{}/permissions-config/users/{}",
+            workspace,
+            repo_slug,
+            encode_path_segment(selected_user)
+        );
+        self.put(&path, &serde_json::json!({ "permission": permission }))
+            .await
+    }
+
+    /// Revoke a user's explicit permission on a repository
+    pub async fn revoke_user_permission(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        selected_user: &str,
+    ) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/permissions-config/users/{}",
+            workspace,
+            repo_slug,
+            encode_path_segment(selected_user)
+        );
+        self.delete(&path).await
+    }
+
+    /// Grant or update a group's explicit permission on a repository.
+    ///
+    /// `group_slug` is the workspace group's slug; `permission` is `read`,
+    /// `write`, or `admin`.
+    pub async fn grant_group_permission(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        group_slug: &str,
+        permission: &str,
+    ) -> Result<GroupPermission> {
+        let path = format!(
+            "/repositories/{}/{}/permissions-config/groups/{}",
+            workspace,
+            repo_slug,
+            encode_path_segment(group_slug)
+        );
+        self.put(&path, &serde_json::json!({ "permission": permission }))
+            .await
+    }
+
+    /// Revoke a group's explicit permission on a repository
+    pub async fn revoke_group_permission(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        group_slug: &str,
+    ) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/permissions-config/groups/{}",
+            workspace,
+            repo_slug,
+            encode_path_segment(group_slug)
+        );
+        self.delete(&path).await
+    }
+}

--- a/src/api/pipelines.rs
+++ b/src/api/pipelines.rs
@@ -1,10 +1,26 @@
 use anyhow::Result;
 
 use super::BitbucketClient;
-use crate::models::{Paginated, Pipeline, PipelineStep, TriggerPipelineRequest};
+use crate::models::{
+    Paginated, Pipeline, PipelineCache, PipelineSchedule, PipelineStep, PipelineVariable,
+    PipelineVariableInput, PipelinesConfig, TriggerPipelineRequest,
+};
+
+/// Server-side filters for [`BitbucketClient::list_pipelines_filtered`].
+#[derive(Default)]
+pub(crate) struct PipelineListFilters<'a> {
+    pub page: Option<u32>,
+    pub pagelen: Option<u32>,
+    pub status: Option<&'a str>,
+    pub target_branch: Option<&'a str>,
+    pub sort: Option<&'a str>,
+}
 
 impl BitbucketClient {
-    /// List pipelines for a repository
+    /// List pipelines for a repository, sorted by most recent first.
+    ///
+    /// Thin wrapper over [`Self::list_pipelines_filtered`] kept for the TUI
+    /// and the build-number/commit lookups, which need no server-side filters.
     pub async fn list_pipelines(
         &self,
         workspace: &str,
@@ -12,18 +28,30 @@ impl BitbucketClient {
         page: Option<u32>,
         pagelen: Option<u32>,
     ) -> Result<Paginated<Pipeline>> {
-        let mut query = Vec::new();
+        self.list_pipelines_filtered(
+            workspace,
+            repo_slug,
+            PipelineListFilters {
+                page,
+                pagelen,
+                ..Default::default()
+            },
+        )
+        .await
+    }
 
-        // Sort by created_on descending to get most recent first
-        query.push(("sort", "-created_on".to_string()));
-
-        if let Some(p) = page {
-            query.push(("page", p.to_string()));
-        }
-        if let Some(len) = pagelen {
-            query.push(("pagelen", len.to_string()));
-        }
-
+    /// List pipelines with optional server-side filters.
+    ///
+    /// `status` filters on pipeline state (e.g. `PENDING`, `IN_PROGRESS`,
+    /// `COMPLETED`), `target_branch` on the target branch name, and `sort`
+    /// overrides the default `-created_on` (most recent first) ordering.
+    pub(crate) async fn list_pipelines_filtered(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        filters: PipelineListFilters<'_>,
+    ) -> Result<Paginated<Pipeline>> {
+        let query = pipeline_list_params(&filters);
         let query_refs: Vec<(&str, &str)> = query.iter().map(|(k, v)| (*k, v.as_str())).collect();
 
         let path = format!("/repositories/{}/{}/pipelines", workspace, repo_slug);
@@ -163,6 +191,271 @@ impl BitbucketClient {
         )
         .await
     }
+
+    // ---- Repository pipeline variables -----------------------------------
+
+    /// List all pipeline variables configured on a repository.
+    pub async fn list_pipeline_variables(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+    ) -> Result<Vec<PipelineVariable>> {
+        let path = format!(
+            "/repositories/{}/{}/pipelines_config/variables/",
+            workspace, repo_slug
+        );
+        self.get_all_pages(&path).await
+    }
+
+    /// Create a new pipeline variable on a repository.
+    pub async fn create_pipeline_variable(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        variable: &PipelineVariableInput,
+    ) -> Result<PipelineVariable> {
+        let path = format!(
+            "/repositories/{}/{}/pipelines_config/variables/",
+            workspace, repo_slug
+        );
+        self.post(&path, variable).await
+    }
+
+    /// Update an existing pipeline variable on a repository.
+    pub async fn update_pipeline_variable(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        variable_uuid: &str,
+        variable: &PipelineVariableInput,
+    ) -> Result<PipelineVariable> {
+        let path = format!(
+            "/repositories/{}/{}/pipelines_config/variables/{}",
+            workspace, repo_slug, variable_uuid
+        );
+        self.put(&path, variable).await
+    }
+
+    /// Delete a pipeline variable from a repository.
+    pub async fn delete_pipeline_variable(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        variable_uuid: &str,
+    ) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/pipelines_config/variables/{}",
+            workspace, repo_slug, variable_uuid
+        );
+        self.delete(&path).await
+    }
+
+    // ---- Workspace pipeline variables -------------------------------------
+
+    /// List all workspace-level pipeline variables.
+    ///
+    /// Note the workspace endpoint uses `pipelines-config` (hyphen), unlike
+    /// the repository endpoint's `pipelines_config`.
+    pub async fn list_workspace_pipeline_variables(
+        &self,
+        workspace: &str,
+    ) -> Result<Vec<PipelineVariable>> {
+        let path = format!("/workspaces/{}/pipelines-config/variables/", workspace);
+        self.get_all_pages(&path).await
+    }
+
+    /// Create a new workspace-level pipeline variable.
+    pub async fn create_workspace_pipeline_variable(
+        &self,
+        workspace: &str,
+        variable: &PipelineVariableInput,
+    ) -> Result<PipelineVariable> {
+        let path = format!("/workspaces/{}/pipelines-config/variables/", workspace);
+        self.post(&path, variable).await
+    }
+
+    /// Update an existing workspace-level pipeline variable.
+    pub async fn update_workspace_pipeline_variable(
+        &self,
+        workspace: &str,
+        variable_uuid: &str,
+        variable: &PipelineVariableInput,
+    ) -> Result<PipelineVariable> {
+        let path = format!(
+            "/workspaces/{}/pipelines-config/variables/{}",
+            workspace, variable_uuid
+        );
+        self.put(&path, variable).await
+    }
+
+    /// Delete a workspace-level pipeline variable.
+    pub async fn delete_workspace_pipeline_variable(
+        &self,
+        workspace: &str,
+        variable_uuid: &str,
+    ) -> Result<()> {
+        let path = format!(
+            "/workspaces/{}/pipelines-config/variables/{}",
+            workspace, variable_uuid
+        );
+        self.delete(&path).await
+    }
+
+    // ---- Pipeline schedules ------------------------------------------------
+
+    /// List all pipeline schedules configured on a repository.
+    pub async fn list_pipeline_schedules(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+    ) -> Result<Vec<PipelineSchedule>> {
+        let path = format!(
+            "/repositories/{}/{}/pipelines_config/schedules/",
+            workspace, repo_slug
+        );
+        self.get_all_pages(&path).await
+    }
+
+    /// Create a pipeline schedule running `branch` on `cron_pattern`.
+    pub async fn create_pipeline_schedule(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        branch: &str,
+        cron_pattern: &str,
+    ) -> Result<PipelineSchedule> {
+        let path = format!(
+            "/repositories/{}/{}/pipelines_config/schedules/",
+            workspace, repo_slug
+        );
+        let body = serde_json::json!({
+            "enabled": true,
+            "target": {
+                "type": "pipeline_ref_target",
+                "ref_type": "branch",
+                "ref_name": branch,
+                "selector": {
+                    "type": "branches",
+                    "pattern": branch,
+                },
+            },
+            "cron_pattern": cron_pattern,
+        });
+        self.post(&path, &body).await
+    }
+
+    /// Delete a pipeline schedule from a repository.
+    pub async fn delete_pipeline_schedule(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        schedule_uuid: &str,
+    ) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/pipelines_config/schedules/{}",
+            workspace, repo_slug, schedule_uuid
+        );
+        self.delete(&path).await
+    }
+
+    // ---- Pipeline caches ----------------------------------------------------
+
+    /// List dependency caches stored for a repository's pipelines.
+    ///
+    /// Note the caches endpoint uses `pipelines-config` (hyphen), unlike the
+    /// variables/schedules endpoints' `pipelines_config`.
+    pub async fn list_pipeline_caches(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+    ) -> Result<Vec<PipelineCache>> {
+        let path = format!(
+            "/repositories/{}/{}/pipelines-config/caches/",
+            workspace, repo_slug
+        );
+        self.get_all_pages(&path).await
+    }
+
+    /// Delete a pipeline dependency cache by UUID.
+    pub async fn delete_pipeline_cache(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        cache_uuid: &str,
+    ) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/pipelines-config/caches/{}",
+            workspace, repo_slug, cache_uuid
+        );
+        self.delete(&path).await
+    }
+
+    // ---- Pipelines configuration ---------------------------------------------
+
+    /// Get the repository's pipelines configuration (enabled state).
+    pub async fn get_pipelines_config(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+    ) -> Result<PipelinesConfig> {
+        let path = format!("/repositories/{}/{}/pipelines_config", workspace, repo_slug);
+        self.get(&path).await
+    }
+
+    /// Enable or disable pipelines on a repository.
+    pub async fn update_pipelines_config_enabled(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        enabled: bool,
+    ) -> Result<PipelinesConfig> {
+        let path = format!("/repositories/{}/{}/pipelines_config", workspace, repo_slug);
+        self.put(&path, &serde_json::json!({ "enabled": enabled }))
+            .await
+    }
+
+    /// Set the next build number for a repository's pipelines.
+    pub async fn set_pipelines_config_build_number(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        next: u64,
+    ) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/pipelines_config/build_number",
+            workspace, repo_slug
+        );
+        let _: serde_json::Value = self
+            .put(&path, &serde_json::json!({ "next": next }))
+            .await?;
+        Ok(())
+    }
+}
+
+/// Assemble the query parameters for a filtered pipeline listing.
+///
+/// `sort` defaults to `-created_on` (most recent first) unless overridden;
+/// `status` is upper-cased to match Bitbucket's enum, and the target-branch
+/// filter is sent under the `target.branch` key the API expects.
+fn pipeline_list_params(filters: &PipelineListFilters<'_>) -> Vec<(&'static str, String)> {
+    let mut query = Vec::new();
+
+    query.push(("sort", filters.sort.unwrap_or("-created_on").to_string()));
+
+    if let Some(status) = filters.status {
+        query.push(("status", status.to_uppercase()));
+    }
+    if let Some(branch) = filters.target_branch {
+        query.push(("target.branch", branch.to_string()));
+    }
+    if let Some(p) = filters.page {
+        query.push(("page", p.to_string()));
+    }
+    if let Some(len) = filters.pagelen {
+        query.push(("pagelen", len.to_string()));
+    }
+
+    query
 }
 
 /// Walk pages of pipelines, newest first, looking for a matching build number.
@@ -224,8 +517,66 @@ mod tests {
 
     use chrono::Utc;
 
-    use super::{commit_hashes_match, find_pipeline_by_build_number};
+    use super::{
+        PipelineListFilters, commit_hashes_match, find_pipeline_by_build_number,
+        pipeline_list_params,
+    };
     use crate::models::{Paginated, Pipeline, PipelineState, PipelineStateName, PipelineTarget};
+
+    fn param<'a>(params: &'a [(&'static str, String)], key: &str) -> Option<&'a str> {
+        params
+            .iter()
+            .find(|(k, _)| *k == key)
+            .map(|(_, v)| v.as_str())
+    }
+
+    #[test]
+    fn params_default_sort_is_created_on_descending() {
+        let params = pipeline_list_params(&PipelineListFilters::default());
+        assert_eq!(param(&params, "sort"), Some("-created_on"));
+    }
+
+    #[test]
+    fn params_sort_override_wins() {
+        let filters = PipelineListFilters {
+            sort: Some("created_on"),
+            ..Default::default()
+        };
+        assert_eq!(
+            param(&pipeline_list_params(&filters), "sort"),
+            Some("created_on")
+        );
+    }
+
+    #[test]
+    fn params_status_is_uppercased() {
+        let filters = PipelineListFilters {
+            status: Some("in_progress"),
+            ..Default::default()
+        };
+        assert_eq!(
+            param(&pipeline_list_params(&filters), "status"),
+            Some("IN_PROGRESS")
+        );
+    }
+
+    #[test]
+    fn params_target_branch_uses_dotted_key() {
+        let filters = PipelineListFilters {
+            target_branch: Some("main"),
+            ..Default::default()
+        };
+        let params = pipeline_list_params(&filters);
+        assert_eq!(param(&params, "target.branch"), Some("main"));
+        // Absent when no branch filter is set.
+        assert_eq!(
+            param(
+                &pipeline_list_params(&PipelineListFilters::default()),
+                "target.branch"
+            ),
+            None
+        );
+    }
 
     fn pipeline(build_number: u64) -> Pipeline {
         Pipeline {

--- a/src/api/projects.rs
+++ b/src/api/projects.rs
@@ -1,0 +1,117 @@
+use anyhow::Result;
+
+use super::BitbucketClient;
+use crate::models::{CreateProjectRequest, Paginated, ProjectDetail, UpdateProjectRequest};
+
+impl BitbucketClient {
+    /// List a page of projects in a workspace.
+    ///
+    /// `query` is a Bitbucket query (BBQL) expression passed as the `q`
+    /// parameter, and `sort` names a field to sort by (prefix with `-` for
+    /// descending).
+    pub async fn list_projects(
+        &self,
+        workspace: &str,
+        query: Option<&str>,
+        sort: Option<&str>,
+        page: Option<u32>,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<ProjectDetail>> {
+        let mut params = Vec::new();
+
+        if let Some(q) = query {
+            params.push(("q", q.to_string()));
+        }
+        if let Some(sort) = sort {
+            params.push(("sort", sort.to_string()));
+        }
+        if let Some(p) = page {
+            params.push(("page", p.to_string()));
+        }
+        if let Some(len) = pagelen {
+            params.push(("pagelen", len.to_string()));
+        }
+
+        let query_refs: Vec<(&str, &str)> = params.iter().map(|(k, v)| (*k, v.as_str())).collect();
+
+        let path = format!("/workspaces/{}/projects", workspace);
+        self.get_with_query(&path, &query_refs).await
+    }
+
+    /// Get a single project by its key
+    pub async fn get_project(&self, workspace: &str, key: &str) -> Result<ProjectDetail> {
+        let path = format!("/workspaces/{}/projects/{}", workspace, key);
+        self.get(&path).await
+    }
+
+    /// Create a new project in a workspace
+    pub async fn create_project(
+        &self,
+        workspace: &str,
+        request: &CreateProjectRequest,
+    ) -> Result<ProjectDetail> {
+        let path = format!("/workspaces/{}/projects", workspace);
+        self.post(&path, request).await
+    }
+
+    /// Update settings on an existing project
+    pub async fn update_project(
+        &self,
+        workspace: &str,
+        key: &str,
+        request: &UpdateProjectRequest,
+    ) -> Result<ProjectDetail> {
+        let path = format!("/workspaces/{}/projects/{}", workspace, key);
+        self.put(&path, request).await
+    }
+
+    /// Delete a project. The project must not contain any repositories.
+    pub async fn delete_project(&self, workspace: &str, key: &str) -> Result<()> {
+        let path = format!("/workspaces/{}/projects/{}", workspace, key);
+        self.delete(&path).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::models::{Paginated, ProjectDetail};
+
+    #[test]
+    fn project_list_payload_deserializes() {
+        let payload = r#"{
+            "pagelen": 10,
+            "page": 1,
+            "size": 2,
+            "values": [
+                {
+                    "uuid": "{a1b2c3d4-0000-1111-2222-333344445555}",
+                    "key": "PROJ",
+                    "name": "My Project",
+                    "description": "The main project",
+                    "is_private": true,
+                    "type": "project",
+                    "created_on": "2020-04-07T21:38:29.542346+00:00",
+                    "updated_on": "2021-06-01T08:00:00.000000+00:00",
+                    "links": {
+                        "html": { "href": "https://bitbucket.org/acme/workspace/projects/PROJ" }
+                    }
+                },
+                {
+                    "key": "OTHER",
+                    "name": "Other",
+                    "type": "project"
+                }
+            ]
+        }"#;
+
+        let page: Paginated<ProjectDetail> = serde_json::from_str(payload).unwrap();
+        assert_eq!(page.values.len(), 2);
+        assert_eq!(page.values[0].key, "PROJ");
+        assert_eq!(page.values[0].is_private, Some(true));
+        assert!(page.values[0].created_on.is_some());
+        assert!(page.values[0].updated_on.is_some());
+        assert_eq!(page.values[1].key, "OTHER");
+        assert!(page.values[1].uuid.is_none());
+        assert!(page.next.is_none());
+    }
+}

--- a/src/api/pullrequests.rs
+++ b/src/api/pullrequests.rs
@@ -2,12 +2,35 @@ use anyhow::Result;
 
 use super::BitbucketClient;
 use crate::models::{
-    CreatePullRequestRequest, MergePullRequestRequest, Paginated, PullRequest, PullRequestComment,
-    PullRequestState,
+    CommentRef, CommitStatus, CreatePullRequestRequest, DiffStat, InlineComment,
+    MergePullRequestRequest, Paginated, PrActivity, PrCommit, PrTask, PullRequest,
+    PullRequestComment, PullRequestState, UpdatePullRequestRequest,
 };
 
+/// Server-side filters for [`BitbucketClient::list_pull_requests_filtered`].
+#[derive(Default)]
+pub(crate) struct PrListFilters<'a> {
+    pub states: &'a [PullRequestState],
+    pub query: Option<&'a str>,
+    pub sort: Option<&'a str>,
+    pub page: Option<u32>,
+    pub pagelen: Option<u32>,
+}
+
+/// Input for [`BitbucketClient::add_pr_comment_full`]: the comment body plus
+/// optional inline placement and reply target.
+pub(crate) struct PrCommentInput<'a> {
+    pub content: &'a str,
+    pub path: Option<&'a str>,
+    pub line: Option<u32>,
+    pub parent: Option<u64>,
+}
+
 impl BitbucketClient {
-    /// List pull requests for a repository
+    /// List pull requests for a repository, filtered by at most one state.
+    ///
+    /// Thin wrapper over [`Self::list_pull_requests_filtered`] kept for
+    /// callers (e.g. the TUI) that only need the simple form.
     pub async fn list_pull_requests(
         &self,
         workspace: &str,
@@ -16,19 +39,47 @@ impl BitbucketClient {
         page: Option<u32>,
         pagelen: Option<u32>,
     ) -> Result<Paginated<PullRequest>> {
-        let mut query = Vec::new();
+        let states: Vec<PullRequestState> = state.into_iter().collect();
+        self.list_pull_requests_filtered(
+            workspace,
+            repo_slug,
+            PrListFilters {
+                states: &states,
+                page,
+                pagelen,
+                ..Default::default()
+            },
+        )
+        .await
+    }
 
-        if let Some(s) = state {
-            query.push(("state", s.to_string()));
+    /// List pull requests with full filtering: multiple `state` values, a
+    /// BBQL `q` expression, a `sort` field, and explicit paging.
+    pub(crate) async fn list_pull_requests_filtered(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        filters: PrListFilters<'_>,
+    ) -> Result<Paginated<PullRequest>> {
+        let mut params = Vec::new();
+
+        for state in filters.states {
+            params.push(("state", state.to_string()));
         }
-        if let Some(p) = page {
-            query.push(("page", p.to_string()));
+        if let Some(q) = filters.query {
+            params.push(("q", q.to_string()));
         }
-        if let Some(len) = pagelen {
-            query.push(("pagelen", len.to_string()));
+        if let Some(s) = filters.sort {
+            params.push(("sort", s.to_string()));
+        }
+        if let Some(p) = filters.page {
+            params.push(("page", p.to_string()));
+        }
+        if let Some(len) = filters.pagelen {
+            params.push(("pagelen", len.to_string()));
         }
 
-        let query_refs: Vec<(&str, &str)> = query.iter().map(|(k, v)| (*k, v.as_str())).collect();
+        let query_refs: Vec<(&str, &str)> = params.iter().map(|(k, v)| (*k, v.as_str())).collect();
 
         let path = format!("/repositories/{}/{}/pullrequests", workspace, repo_slug);
         self.get_with_query(&path, &query_refs).await
@@ -59,33 +110,19 @@ impl BitbucketClient {
         self.post(&path, request).await
     }
 
-    /// Update a pull request
+    /// Update a pull request; only the fields set on `request` are changed.
     pub async fn update_pull_request(
         &self,
         workspace: &str,
         repo_slug: &str,
         pr_id: u64,
-        title: Option<&str>,
-        description: Option<&str>,
+        request: &UpdatePullRequestRequest,
     ) -> Result<PullRequest> {
-        #[derive(serde::Serialize)]
-        struct UpdateRequest {
-            #[serde(skip_serializing_if = "Option::is_none")]
-            title: Option<String>,
-            #[serde(skip_serializing_if = "Option::is_none")]
-            description: Option<String>,
-        }
-
-        let request = UpdateRequest {
-            title: title.map(|t| t.to_string()),
-            description: description.map(|d| d.to_string()),
-        };
-
         let path = format!(
             "/repositories/{}/{}/pullrequests/{}",
             workspace, repo_slug, pr_id
         );
-        self.put(&path, &request).await
+        self.put(&path, request).await
     }
 
     /// Merge a pull request
@@ -129,6 +166,34 @@ impl BitbucketClient {
     ) -> Result<()> {
         let path = format!(
             "/repositories/{}/{}/pullrequests/{}/approve",
+            workspace, repo_slug, pr_id
+        );
+        self.delete(&path).await
+    }
+
+    /// Request changes on a pull request
+    pub async fn request_pr_changes(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pr_id: u64,
+    ) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/pullrequests/{}/request-changes",
+            workspace, repo_slug, pr_id
+        );
+        self.post_no_response(&path, &serde_json::json!({})).await
+    }
+
+    /// Withdraw a previous request for changes on a pull request
+    pub async fn unrequest_pr_changes(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pr_id: u64,
+    ) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/pullrequests/{}/request-changes",
             workspace, repo_slug, pr_id
         );
         self.delete(&path).await
@@ -191,17 +256,22 @@ impl BitbucketClient {
         self.get(&path).await
     }
 
-    /// Add a comment to a pull request
-    pub async fn add_pr_comment(
+    /// Add a comment to a pull request, optionally inline (`path` + `line`)
+    /// and/or as a reply to `parent`.
+    pub(crate) async fn add_pr_comment_full(
         &self,
         workspace: &str,
         repo_slug: &str,
         pr_id: u64,
-        content: &str,
+        input: PrCommentInput<'_>,
     ) -> Result<PullRequestComment> {
         #[derive(serde::Serialize)]
         struct CommentRequest {
             content: ContentRequest,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            inline: Option<InlineComment>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            parent: Option<CommentRef>,
         }
 
         #[derive(serde::Serialize)]
@@ -211,15 +281,84 @@ impl BitbucketClient {
 
         let request = CommentRequest {
             content: ContentRequest {
-                raw: content.to_string(),
+                raw: input.content.to_string(),
             },
+            inline: input.path.map(|p| InlineComment {
+                from: None,
+                to: input.line,
+                path: p.to_string(),
+            }),
+            parent: input.parent.map(|id| CommentRef { id }),
         };
 
-        let path = format!(
+        let api_path = format!(
             "/repositories/{}/{}/pullrequests/{}/comments",
             workspace, repo_slug, pr_id
         );
-        self.post(&path, &request).await
+        self.post(&api_path, &request).await
+    }
+
+    /// Update the content of an existing pull request comment
+    pub async fn update_pr_comment(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pr_id: u64,
+        comment_id: u64,
+        content: &str,
+    ) -> Result<PullRequestComment> {
+        let request = serde_json::json!({ "content": { "raw": content } });
+
+        let path = format!(
+            "/repositories/{}/{}/pullrequests/{}/comments/{}",
+            workspace, repo_slug, pr_id, comment_id
+        );
+        self.put(&path, &request).await
+    }
+
+    /// Delete a pull request comment
+    pub async fn delete_pr_comment(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pr_id: u64,
+        comment_id: u64,
+    ) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/pullrequests/{}/comments/{}",
+            workspace, repo_slug, pr_id, comment_id
+        );
+        self.delete(&path).await
+    }
+
+    /// Resolve a pull request comment thread
+    pub async fn resolve_pr_comment(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pr_id: u64,
+        comment_id: u64,
+    ) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/pullrequests/{}/comments/{}/resolve",
+            workspace, repo_slug, pr_id, comment_id
+        );
+        self.post_no_response(&path, &serde_json::json!({})).await
+    }
+
+    /// Reopen (unresolve) a pull request comment thread
+    pub async fn unresolve_pr_comment(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pr_id: u64,
+        comment_id: u64,
+    ) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/pullrequests/{}/comments/{}/resolve",
+            workspace, repo_slug, pr_id, comment_id
+        );
+        self.delete(&path).await
     }
 
     /// Get the diff for a pull request
@@ -235,6 +374,186 @@ impl BitbucketClient {
         );
 
         self.get_text(&path, Some("text/plain")).await
+    }
+
+    /// Get the patch (mbox-style) for a pull request
+    pub async fn get_pr_patch(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pr_id: u64,
+    ) -> Result<String> {
+        let path = format!(
+            "/repositories/{}/{}/pullrequests/{}/patch",
+            workspace, repo_slug, pr_id
+        );
+
+        self.get_text(&path, None).await
+    }
+
+    /// List one page of commits on a pull request
+    pub async fn list_pr_commits(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pr_id: u64,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<PrCommit>> {
+        let path = format!(
+            "/repositories/{}/{}/pullrequests/{}/commits",
+            workspace, repo_slug, pr_id
+        );
+
+        match pagelen {
+            Some(len) => {
+                let len = len.to_string();
+                self.get_with_query(&path, &[("pagelen", len.as_str())])
+                    .await
+            }
+            None => self.get(&path).await,
+        }
+    }
+
+    /// List all commit statuses (builds) for a pull request's head commit
+    pub async fn list_pr_statuses(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pr_id: u64,
+    ) -> Result<Vec<CommitStatus>> {
+        let path = format!(
+            "/repositories/{}/{}/pullrequests/{}/statuses",
+            workspace, repo_slug, pr_id
+        );
+        self.get_all_pages(&path).await
+    }
+
+    /// Get one page of the diffstat (per-file change summary) for a pull request
+    pub async fn get_pr_diffstat(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pr_id: u64,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<DiffStat>> {
+        let path = format!(
+            "/repositories/{}/{}/pullrequests/{}/diffstat",
+            workspace, repo_slug, pr_id
+        );
+
+        match pagelen {
+            Some(len) => {
+                let len = len.to_string();
+                self.get_with_query(&path, &[("pagelen", len.as_str())])
+                    .await
+            }
+            None => self.get(&path).await,
+        }
+    }
+
+    /// List all tasks on a pull request
+    pub async fn list_pr_tasks(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pr_id: u64,
+    ) -> Result<Vec<PrTask>> {
+        let path = format!(
+            "/repositories/{}/{}/pullrequests/{}/tasks",
+            workspace, repo_slug, pr_id
+        );
+        self.get_all_pages(&path).await
+    }
+
+    /// Create a task on a pull request
+    pub async fn add_pr_task(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pr_id: u64,
+        content: &str,
+    ) -> Result<PrTask> {
+        let request = serde_json::json!({ "content": { "raw": content } });
+
+        let path = format!(
+            "/repositories/{}/{}/pullrequests/{}/tasks",
+            workspace, repo_slug, pr_id
+        );
+        self.post(&path, &request).await
+    }
+
+    /// Update a pull request task's content and/or state
+    /// (`state` is `"RESOLVED"` or `"UNRESOLVED"`).
+    pub async fn update_pr_task(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pr_id: u64,
+        task_id: u64,
+        content: Option<&str>,
+        state: Option<&str>,
+    ) -> Result<PrTask> {
+        #[derive(serde::Serialize)]
+        struct TaskUpdateRequest {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            content: Option<TaskContentRequest>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            state: Option<String>,
+        }
+
+        #[derive(serde::Serialize)]
+        struct TaskContentRequest {
+            raw: String,
+        }
+
+        let request = TaskUpdateRequest {
+            content: content.map(|c| TaskContentRequest { raw: c.to_string() }),
+            state: state.map(|s| s.to_string()),
+        };
+
+        let path = format!(
+            "/repositories/{}/{}/pullrequests/{}/tasks/{}",
+            workspace, repo_slug, pr_id, task_id
+        );
+        self.put(&path, &request).await
+    }
+
+    /// Delete a pull request task
+    pub async fn delete_pr_task(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pr_id: u64,
+        task_id: u64,
+    ) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/pullrequests/{}/tasks/{}",
+            workspace, repo_slug, pr_id, task_id
+        );
+        self.delete(&path).await
+    }
+
+    /// List one page of the activity feed for a pull request
+    pub async fn list_pr_activity(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pr_id: u64,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<PrActivity>> {
+        let path = format!(
+            "/repositories/{}/{}/pullrequests/{}/activity",
+            workspace, repo_slug, pr_id
+        );
+
+        match pagelen {
+            Some(len) => {
+                let len = len.to_string();
+                self.get_with_query(&path, &[("pagelen", len.as_str())])
+                    .await
+            }
+            None => self.get(&path).await,
+        }
     }
 }
 

--- a/src/api/refs.rs
+++ b/src/api/refs.rs
@@ -1,0 +1,180 @@
+use anyhow::Result;
+
+use super::BitbucketClient;
+use crate::api::util::urlencode_segment;
+use crate::models::{
+    BranchDetail, CreateBranchRequest, CreateTagRequest, Paginated, RefTarget, TagDetail,
+};
+
+impl BitbucketClient {
+    /// List branches in a repository, optionally filtered and sorted.
+    ///
+    /// `query` is a Bitbucket filter expression (e.g. `name ~ "feat"`) passed
+    /// as `q`; `sort` is a field name, prefix with `-` for descending
+    /// (e.g. `-target.date`).
+    pub async fn list_branches_filtered(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        query: Option<&str>,
+        sort: Option<&str>,
+        page: Option<u32>,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<BranchDetail>> {
+        let path = format!("/repositories/{}/{}/refs/branches", workspace, repo_slug);
+        self.get_ref_page(&path, query, sort, page, pagelen).await
+    }
+
+    /// Create a branch pointing at `target_hash`.
+    pub async fn create_branch(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        name: &str,
+        target_hash: &str,
+    ) -> Result<BranchDetail> {
+        let path = format!("/repositories/{}/{}/refs/branches", workspace, repo_slug);
+        let request = CreateBranchRequest {
+            name: name.to_string(),
+            target: RefTarget {
+                hash: target_hash.to_string(),
+            },
+        };
+        self.post(&path, &request).await
+    }
+
+    /// Get a single branch by name.
+    pub async fn get_branch(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        name: &str,
+    ) -> Result<BranchDetail> {
+        let path = format!(
+            "/repositories/{}/{}/refs/branches/{}",
+            workspace,
+            repo_slug,
+            urlencode_segment(name)
+        );
+        self.get(&path).await
+    }
+
+    /// Delete a branch by name.
+    pub async fn delete_branch(&self, workspace: &str, repo_slug: &str, name: &str) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/refs/branches/{}",
+            workspace,
+            repo_slug,
+            urlencode_segment(name)
+        );
+        self.delete(&path).await
+    }
+
+    /// List tags in a repository, optionally filtered and sorted.
+    ///
+    /// `query` and `sort` behave as in [`Self::list_branches_filtered`].
+    pub async fn list_tags_filtered(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        query: Option<&str>,
+        sort: Option<&str>,
+        page: Option<u32>,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<TagDetail>> {
+        let path = format!("/repositories/{}/{}/refs/tags", workspace, repo_slug);
+        self.get_ref_page(&path, query, sort, page, pagelen).await
+    }
+
+    /// Create a tag pointing at `target_hash`. Passing a `message` creates an
+    /// annotated tag; omitting it creates a lightweight tag.
+    pub async fn create_tag(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        name: &str,
+        target_hash: &str,
+        message: Option<&str>,
+    ) -> Result<TagDetail> {
+        let path = format!("/repositories/{}/{}/refs/tags", workspace, repo_slug);
+        let request = CreateTagRequest {
+            name: name.to_string(),
+            target: RefTarget {
+                hash: target_hash.to_string(),
+            },
+            message: message.map(String::from),
+        };
+        self.post(&path, &request).await
+    }
+
+    /// Get a single tag by name.
+    pub async fn get_tag(&self, workspace: &str, repo_slug: &str, name: &str) -> Result<TagDetail> {
+        let path = format!(
+            "/repositories/{}/{}/refs/tags/{}",
+            workspace,
+            repo_slug,
+            urlencode_segment(name)
+        );
+        self.get(&path).await
+    }
+
+    /// Delete a tag by name.
+    pub async fn delete_tag(&self, workspace: &str, repo_slug: &str, name: &str) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/refs/tags/{}",
+            workspace,
+            repo_slug,
+            urlencode_segment(name)
+        );
+        self.delete(&path).await
+    }
+
+    /// Shared GET for both ref-listing endpoints: attaches the optional
+    /// `q` / `sort` / `page` / `pagelen` query parameters.
+    async fn get_ref_page<T: serde::de::DeserializeOwned>(
+        &self,
+        path: &str,
+        query: Option<&str>,
+        sort: Option<&str>,
+        page: Option<u32>,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<T>> {
+        let mut params = Vec::new();
+
+        if let Some(q) = query {
+            params.push(("q", q.to_string()));
+        }
+        if let Some(s) = sort {
+            params.push(("sort", s.to_string()));
+        }
+        if let Some(p) = page {
+            params.push(("page", p.to_string()));
+        }
+        if let Some(len) = pagelen {
+            params.push(("pagelen", len.to_string()));
+        }
+
+        let param_refs: Vec<(&str, &str)> = params.iter().map(|(k, v)| (*k, v.as_str())).collect();
+        self.get_with_query(path, &param_refs).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn urlencode_leaves_safe_chars_untouched() {
+        assert_eq!(urlencode_segment("v1.0.0-rc_2~x"), "v1.0.0-rc_2~x");
+    }
+
+    #[test]
+    fn urlencode_encodes_slash_in_branch_names() {
+        assert_eq!(urlencode_segment("feature/login"), "feature%2Flogin");
+    }
+
+    #[test]
+    fn urlencode_encodes_spaces_and_specials() {
+        assert_eq!(urlencode_segment("wip branch#1"), "wip%20branch%231");
+    }
+}

--- a/src/api/repos.rs
+++ b/src/api/repos.rs
@@ -11,16 +11,44 @@ impl BitbucketClient {
         page: Option<u32>,
         pagelen: Option<u32>,
     ) -> Result<Paginated<Repository>> {
-        let mut query = Vec::new();
+        self.list_repositories_filtered(workspace, None, None, None, page, pagelen)
+            .await
+    }
 
+    /// List repositories for a workspace with optional filters.
+    ///
+    /// `role` restricts results to repositories where the caller has at least
+    /// that role (member, contributor, admin, or owner), `query` is a
+    /// Bitbucket query (BBQL) expression passed as the `q` parameter, and
+    /// `sort` names a field to sort by (prefix with `-` for descending).
+    pub async fn list_repositories_filtered(
+        &self,
+        workspace: &str,
+        role: Option<&str>,
+        query: Option<&str>,
+        sort: Option<&str>,
+        page: Option<u32>,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<Repository>> {
+        let mut params = Vec::new();
+
+        if let Some(role) = role {
+            params.push(("role", role.to_string()));
+        }
+        if let Some(q) = query {
+            params.push(("q", q.to_string()));
+        }
+        if let Some(sort) = sort {
+            params.push(("sort", sort.to_string()));
+        }
         if let Some(p) = page {
-            query.push(("page", p.to_string()));
+            params.push(("page", p.to_string()));
         }
         if let Some(len) = pagelen {
-            query.push(("pagelen", len.to_string()));
+            params.push(("pagelen", len.to_string()));
         }
 
-        let query_refs: Vec<(&str, &str)> = query.iter().map(|(k, v)| (*k, v.as_str())).collect();
+        let query_refs: Vec<(&str, &str)> = params.iter().map(|(k, v)| (*k, v.as_str())).collect();
 
         let path = format!("/repositories/{}", workspace);
         self.get_with_query(&path, &query_refs).await
@@ -92,23 +120,39 @@ impl BitbucketClient {
         self.post(&path, &request).await
     }
 
-    /// List repository branches
-    pub async fn list_branches(
+    /// List users watching a repository
+    pub async fn list_watchers(
         &self,
         workspace: &str,
         repo_slug: &str,
-    ) -> Result<Paginated<crate::models::Branch>> {
-        let path = format!("/repositories/{}/{}/refs/branches", workspace, repo_slug);
-        self.get(&path).await
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<crate::models::User>> {
+        let path = format!("/repositories/{}/{}/watchers", workspace, repo_slug);
+        match pagelen {
+            Some(len) => {
+                let len = len.to_string();
+                self.get_with_query(&path, &[("pagelen", len.as_str())])
+                    .await
+            }
+            None => self.get(&path).await,
+        }
     }
 
-    /// Get the main branch
-    pub async fn get_main_branch(
+    /// List forks of a repository
+    pub async fn list_forks(
         &self,
         workspace: &str,
         repo_slug: &str,
-    ) -> Result<crate::models::Branch> {
-        let path = format!("/repositories/{}/{}/main-branch", workspace, repo_slug);
-        self.get(&path).await
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<Repository>> {
+        let path = format!("/repositories/{}/{}/forks", workspace, repo_slug);
+        match pagelen {
+            Some(len) => {
+                let len = len.to_string();
+                self.get_with_query(&path, &[("pagelen", len.as_str())])
+                    .await
+            }
+            None => self.get(&path).await,
+        }
     }
 }

--- a/src/api/source.rs
+++ b/src/api/source.rs
@@ -1,0 +1,135 @@
+use anyhow::Result;
+
+use super::BitbucketClient;
+use crate::api::util::urlencode_segment;
+use crate::models::{FileHistoryEntry, Paginated, SourceEntry};
+
+impl BitbucketClient {
+    /// List the entries of a directory at `path` (empty string for the
+    /// repository root) as of `git_ref` (branch, tag, or commit hash).
+    pub async fn list_source(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        git_ref: &str,
+        path: &str,
+        page: Option<u32>,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<SourceEntry>> {
+        let endpoint = source_path(workspace, repo_slug, git_ref, path);
+
+        let mut params = Vec::new();
+        if let Some(p) = page {
+            params.push(("page", p.to_string()));
+        }
+        if let Some(len) = pagelen {
+            params.push(("pagelen", len.to_string()));
+        }
+
+        let param_refs: Vec<(&str, &str)> = params.iter().map(|(k, v)| (*k, v.as_str())).collect();
+        self.get_with_query(&endpoint, &param_refs).await
+    }
+
+    /// Fetch the raw contents of the file at `path` as of `git_ref`.
+    ///
+    /// This is the same endpoint as [`Self::list_source`]; pointed at a file
+    /// instead of a directory, it returns the file body verbatim.
+    pub async fn get_file_raw(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        git_ref: &str,
+        path: &str,
+    ) -> Result<String> {
+        let endpoint = source_path(workspace, repo_slug, git_ref, path);
+        self.get_text(&endpoint, None).await
+    }
+
+    /// List the commits that touched the file at `path`, starting from
+    /// `git_ref`, newest first.
+    pub async fn get_file_history(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        git_ref: &str,
+        path: &str,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<FileHistoryEntry>> {
+        let endpoint = format!(
+            "/repositories/{}/{}/filehistory/{}/{}",
+            workspace,
+            repo_slug,
+            urlencode_segment(git_ref),
+            urlencode_path(path)
+        );
+
+        let mut params = Vec::new();
+        if let Some(len) = pagelen {
+            params.push(("pagelen", len.to_string()));
+        }
+
+        let param_refs: Vec<(&str, &str)> = params.iter().map(|(k, v)| (*k, v.as_str())).collect();
+        self.get_with_query(&endpoint, &param_refs).await
+    }
+}
+
+/// Build the `src/{ref}/{path}` endpoint path. An empty `path` targets the
+/// repository root; the trailing slash tells Bitbucket to return a directory
+/// listing rather than a ref redirect.
+fn source_path(workspace: &str, repo_slug: &str, git_ref: &str, path: &str) -> String {
+    let base = format!(
+        "/repositories/{}/{}/src/{}",
+        workspace,
+        repo_slug,
+        urlencode_segment(git_ref)
+    );
+
+    if path.is_empty() {
+        format!("{}/", base)
+    } else {
+        format!("{}/{}", base, urlencode_path(path))
+    }
+}
+
+/// Percent-encode a repository file path: each component is encoded as a
+/// path segment while the `/` separators are preserved.
+fn urlencode_path(path: &str) -> String {
+    path.split('/')
+        .map(urlencode_segment)
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn urlencode_path_preserves_separators() {
+        assert_eq!(urlencode_path("src/api/mod.rs"), "src/api/mod.rs");
+    }
+
+    #[test]
+    fn urlencode_path_encodes_specials_within_segments() {
+        assert_eq!(
+            urlencode_path("docs/release notes/v1 (draft).md"),
+            "docs/release%20notes/v1%20%28draft%29.md"
+        );
+    }
+
+    #[test]
+    fn source_path_uses_trailing_slash_for_root() {
+        assert_eq!(
+            source_path("acme", "widgets", "main", ""),
+            "/repositories/acme/widgets/src/main/"
+        );
+    }
+
+    #[test]
+    fn source_path_appends_encoded_file_path() {
+        assert_eq!(
+            source_path("acme", "widgets", "feature/x", "src/lib.rs"),
+            "/repositories/acme/widgets/src/feature%2Fx/src/lib.rs"
+        );
+    }
+}

--- a/src/api/users.rs
+++ b/src/api/users.rs
@@ -1,0 +1,77 @@
+use anyhow::Result;
+
+use super::BitbucketClient;
+use crate::api::util::urlencode_segment;
+use crate::models::{Paginated, User, UserEmail};
+
+impl BitbucketClient {
+    /// Fetch the profile of the currently authenticated user.
+    pub async fn get_current_user(&self) -> Result<User> {
+        self.get("/user").await
+    }
+
+    /// Fetch a user's public profile.
+    ///
+    /// `selected` may be an account ID or a UUID (including surrounding
+    /// braces, which are percent-encoded for the URL path).
+    pub async fn get_user(&self, selected: &str) -> Result<User> {
+        let path = format!("/users/{}", urlencode_segment(selected));
+        self.get(&path).await
+    }
+
+    /// List the email addresses associated with the authenticated user.
+    pub async fn list_user_emails(&self) -> Result<Paginated<UserEmail>> {
+        self.get("/user/emails").await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{Paginated, UserEmail};
+
+    #[test]
+    fn urlencode_encodes_uuid_braces() {
+        assert_eq!(
+            urlencode_segment("{a1b2c3d4-0000-1111-2222-333344445555}"),
+            "%7Ba1b2c3d4-0000-1111-2222-333344445555%7D"
+        );
+    }
+
+    #[test]
+    fn urlencode_leaves_account_ids_untouched() {
+        assert_eq!(
+            urlencode_segment("557058:c0b72ad0-1234-5678-9abc-def012345678"),
+            "557058%3Ac0b72ad0-1234-5678-9abc-def012345678"
+        );
+    }
+
+    #[test]
+    fn user_emails_payload_deserializes() {
+        let payload = r#"{
+            "pagelen": 10,
+            "page": 1,
+            "size": 2,
+            "values": [
+                {
+                    "email": "primary@example.com",
+                    "is_primary": true,
+                    "is_confirmed": true,
+                    "type": "email"
+                },
+                {
+                    "email": "alt@example.com",
+                    "is_primary": false,
+                    "is_confirmed": false,
+                    "type": "email"
+                }
+            ]
+        }"#;
+
+        let page: Paginated<UserEmail> = serde_json::from_str(payload).unwrap();
+        assert_eq!(page.values.len(), 2);
+        assert_eq!(page.values[0].email.as_deref(), Some("primary@example.com"));
+        assert_eq!(page.values[0].is_primary, Some(true));
+        assert_eq!(page.values[1].is_confirmed, Some(false));
+    }
+}

--- a/src/api/util.rs
+++ b/src/api/util.rs
@@ -1,0 +1,48 @@
+//! Shared low-level helpers for the API layer.
+
+/// Percent-encode a single URL path segment per RFC 3986, escaping everything
+/// outside the unreserved set (`A-Z a-z 0-9 - _ . ~`). Used to safely embed
+/// branch names, tags, artifact names, brace-wrapped UUIDs, and account IDs
+/// into request paths.
+pub(crate) fn urlencode_segment(s: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => {
+                out.push('%');
+                out.push(HEX[(b >> 4) as usize] as char);
+                out.push(HEX[(b & 0xf) as usize] as char);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::urlencode_segment;
+
+    #[test]
+    fn leaves_unreserved_untouched() {
+        assert_eq!(
+            urlencode_segment("Feature.branch-1_v~2"),
+            "Feature.branch-1_v~2"
+        );
+    }
+
+    #[test]
+    fn encodes_slashes_and_braces() {
+        assert_eq!(urlencode_segment("feature/login"), "feature%2Flogin");
+        assert_eq!(urlencode_segment("{uuid}"), "%7Buuid%7D");
+    }
+
+    #[test]
+    fn encodes_space_and_colon_and_utf8() {
+        assert_eq!(urlencode_segment("a b:c"), "a%20b%3Ac");
+        assert_eq!(urlencode_segment("é"), "%C3%A9");
+    }
+}

--- a/src/api/webhooks.rs
+++ b/src/api/webhooks.rs
@@ -1,0 +1,132 @@
+use anyhow::Result;
+
+use super::BitbucketClient;
+use crate::models::{CreateWebhookRequest, Paginated, Webhook};
+
+/// Percent-encode a string for use as a single URL path segment.
+///
+/// Bitbucket identifiers such as webhook UIDs (a UUID wrapped in braces,
+/// e.g. `{1a2b-...}`) and permission selectors (`{uuid}`, account IDs with
+/// `:`) contain characters that are not valid raw path characters, so
+/// everything outside the RFC 3986 "unreserved" set is percent-encoded.
+pub(crate) fn encode_path_segment(segment: &str) -> String {
+    let mut encoded = String::with_capacity(segment.len());
+    for byte in segment.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(byte as char);
+            }
+            _ => encoded.push_str(&format!("%{:02X}", byte)),
+        }
+    }
+    encoded
+}
+
+impl BitbucketClient {
+    /// List webhook subscriptions on a repository
+    pub async fn list_webhooks(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<Webhook>> {
+        let path = format!("/repositories/{}/{}/hooks", workspace, repo_slug);
+
+        match pagelen {
+            Some(len) => {
+                self.get_with_query(&path, &[("pagelen", len.to_string().as_str())])
+                    .await
+            }
+            None => self.get(&path).await,
+        }
+    }
+
+    /// Create a webhook subscription on a repository
+    pub async fn create_webhook(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        request: &CreateWebhookRequest,
+    ) -> Result<Webhook> {
+        let path = format!("/repositories/{}/{}/hooks", workspace, repo_slug);
+        self.post(&path, request).await
+    }
+
+    /// Get a single webhook subscription by its UID (the brace-wrapped UUID)
+    pub async fn get_webhook(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        uid: &str,
+    ) -> Result<Webhook> {
+        let path = format!(
+            "/repositories/{}/{}/hooks/{}",
+            workspace,
+            repo_slug,
+            encode_path_segment(uid)
+        );
+        self.get(&path).await
+    }
+
+    /// Replace a webhook subscription.
+    ///
+    /// Bitbucket's PUT replaces the entire subscription, so `request` must
+    /// carry the full desired state (see [`CreateWebhookRequest`]).
+    pub async fn update_webhook(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        uid: &str,
+        request: &CreateWebhookRequest,
+    ) -> Result<Webhook> {
+        let path = format!(
+            "/repositories/{}/{}/hooks/{}",
+            workspace,
+            repo_slug,
+            encode_path_segment(uid)
+        );
+        self.put(&path, request).await
+    }
+
+    /// Delete a webhook subscription
+    pub async fn delete_webhook(&self, workspace: &str, repo_slug: &str, uid: &str) -> Result<()> {
+        let path = format!(
+            "/repositories/{}/{}/hooks/{}",
+            workspace,
+            repo_slug,
+            encode_path_segment(uid)
+        );
+        self.delete(&path).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::encode_path_segment;
+
+    #[test]
+    fn encode_path_segment_passes_unreserved_through() {
+        assert_eq!(
+            encode_path_segment("abc-XYZ_0.9~"),
+            "abc-XYZ_0.9~".to_string()
+        );
+    }
+
+    #[test]
+    fn encode_path_segment_encodes_webhook_uid_braces() {
+        assert_eq!(
+            encode_path_segment("{d3a1e9b0-1234-5678-9abc-def012345678}"),
+            "%7Bd3a1e9b0-1234-5678-9abc-def012345678%7D"
+        );
+    }
+
+    #[test]
+    fn encode_path_segment_encodes_reserved_ascii() {
+        assert_eq!(encode_path_segment("a/b:c d"), "a%2Fb%3Ac%20d");
+    }
+
+    #[test]
+    fn encode_path_segment_encodes_utf8_bytes() {
+        assert_eq!(encode_path_segment("é"), "%C3%A9");
+    }
+}

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 use super::BitbucketClient;
-use crate::models::Workspace;
+use crate::models::{Paginated, Workspace, WorkspaceMembership, WorkspacePermission};
 
 impl BitbucketClient {
     /// List all workspaces the authenticated user has access to,
@@ -9,11 +9,101 @@ impl BitbucketClient {
     pub async fn list_workspaces(&self) -> Result<Vec<Workspace>> {
         self.get_all_pages("/workspaces").await
     }
+
+    /// List a single page of workspaces with optional filters.
+    ///
+    /// `role` restricts results to workspaces where the caller has at least
+    /// that role (member, collaborator, or owner), `query` is a Bitbucket
+    /// query (BBQL) expression passed as the `q` parameter, and `sort` names
+    /// a field to sort by (prefix with `-` for descending).
+    pub async fn list_workspaces_filtered(
+        &self,
+        role: Option<&str>,
+        query: Option<&str>,
+        sort: Option<&str>,
+        page: Option<u32>,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<Workspace>> {
+        let mut params = Vec::new();
+
+        if let Some(role) = role {
+            params.push(("role", role.to_string()));
+        }
+        if let Some(q) = query {
+            params.push(("q", q.to_string()));
+        }
+        if let Some(sort) = sort {
+            params.push(("sort", sort.to_string()));
+        }
+        if let Some(p) = page {
+            params.push(("page", p.to_string()));
+        }
+        if let Some(len) = pagelen {
+            params.push(("pagelen", len.to_string()));
+        }
+
+        let query_refs: Vec<(&str, &str)> = params.iter().map(|(k, v)| (*k, v.as_str())).collect();
+
+        self.get_with_query("/workspaces", &query_refs).await
+    }
+
+    /// Get a single workspace by slug or UUID
+    pub async fn get_workspace(&self, workspace: &str) -> Result<Workspace> {
+        let path = format!("/workspaces/{}", workspace);
+        self.get(&path).await
+    }
+
+    /// List a page of members of a workspace
+    pub async fn list_workspace_members(
+        &self,
+        workspace: &str,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<WorkspaceMembership>> {
+        let path = format!("/workspaces/{}/members", workspace);
+        match pagelen {
+            Some(len) => {
+                let len = len.to_string();
+                self.get_with_query(&path, &[("pagelen", len.as_str())])
+                    .await
+            }
+            None => self.get(&path).await,
+        }
+    }
+
+    /// List a page of user permissions on a workspace, or — when `repo_slug`
+    /// is given — on a single repository in that workspace.
+    pub async fn list_workspace_permissions(
+        &self,
+        workspace: &str,
+        repo_slug: Option<&str>,
+        page: Option<u32>,
+        pagelen: Option<u32>,
+    ) -> Result<Paginated<WorkspacePermission>> {
+        let path = match repo_slug {
+            Some(repo) => format!(
+                "/workspaces/{}/permissions/repositories/{}",
+                workspace, repo
+            ),
+            None => format!("/workspaces/{}/permissions", workspace),
+        };
+
+        let mut params = Vec::new();
+        if let Some(p) = page {
+            params.push(("page", p.to_string()));
+        }
+        if let Some(len) = pagelen {
+            params.push(("pagelen", len.to_string()));
+        }
+
+        let query_refs: Vec<(&str, &str)> = params.iter().map(|(k, v)| (*k, v.as_str())).collect();
+
+        self.get_with_query(&path, &query_refs).await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::models::{Paginated, Workspace};
+    use crate::models::{Paginated, Workspace, WorkspaceMembership, WorkspacePermission};
 
     #[test]
     fn workspace_list_payload_deserializes() {
@@ -50,5 +140,65 @@ mod tests {
         assert!(page.values[0].created_on.is_some());
         assert_eq!(page.values[1].is_private, None);
         assert!(page.next.is_none());
+    }
+
+    #[test]
+    fn workspace_members_payload_deserializes() {
+        let payload = r#"{
+            "pagelen": 50,
+            "page": 1,
+            "size": 1,
+            "values": [
+                {
+                    "type": "workspace_membership",
+                    "user": {
+                        "uuid": "{c3d4e5f6-0000-1111-2222-333344445555}",
+                        "display_name": "Jane Doe",
+                        "nickname": "jdoe",
+                        "type": "user"
+                    },
+                    "workspace": {
+                        "uuid": "{a1b2c3d4-0000-1111-2222-333344445555}",
+                        "slug": "my-workspace",
+                        "name": "My Workspace",
+                        "type": "workspace"
+                    }
+                }
+            ]
+        }"#;
+
+        let page: Paginated<WorkspaceMembership> = serde_json::from_str(payload).unwrap();
+        assert_eq!(page.values.len(), 1);
+        let member = &page.values[0];
+        assert_eq!(member.user.as_ref().unwrap().display_name, "Jane Doe");
+        assert_eq!(member.workspace.as_ref().unwrap().slug, "my-workspace");
+    }
+
+    #[test]
+    fn workspace_permissions_payload_deserializes() {
+        let payload = r#"{
+            "pagelen": 50,
+            "page": 1,
+            "size": 1,
+            "values": [
+                {
+                    "type": "workspace_membership",
+                    "permission": "owner",
+                    "user": {
+                        "uuid": "{c3d4e5f6-0000-1111-2222-333344445555}",
+                        "display_name": "Jane Doe",
+                        "type": "user"
+                    }
+                }
+            ]
+        }"#;
+
+        let page: Paginated<WorkspacePermission> = serde_json::from_str(payload).unwrap();
+        assert_eq!(page.values.len(), 1);
+        assert_eq!(page.values[0].permission.as_deref(), Some("owner"));
+        assert_eq!(
+            page.values[0].user.as_ref().unwrap().display_name,
+            "Jane Doe"
+        );
     }
 }

--- a/src/auth/api_key.rs
+++ b/src/auth/api_key.rs
@@ -102,14 +102,18 @@ impl ApiKeyAuth {
 
     /// Validate credentials against the Bitbucket API
     async fn validate_credentials(credential: &Credential) -> Result<()> {
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .user_agent(crate::api::client::USER_AGENT)
+            .build()
+            .context("Failed to create HTTP client")?;
 
         println!("🔍 Validating credentials with Bitbucket API...");
 
         let response = client
             .get("https://api.bitbucket.org/2.0/user")
             .header("Authorization", credential.auth_header())
-            .header("User-Agent", "bitbucket-cli/0.3.0")
             .send()
             .await
             .context("Failed to connect to Bitbucket API")?;

--- a/src/cli/branch.rs
+++ b/src/cli/branch.rs
@@ -1,0 +1,279 @@
+use anyhow::{Context, Result};
+use clap::Subcommand;
+use colored::Colorize;
+use tabled::{Table, Tabled};
+
+use super::commit::{author_label, first_line_truncated, short_hash};
+use super::{confirm_or_abort, output_json, parse_repo, print_json};
+use crate::api::BitbucketClient;
+use crate::cli::pagination::effective_limit;
+use crate::models::BranchDetail;
+
+/// Width of the truncated commit-message column in list tables.
+const MSG_WIDTH: usize = 50;
+
+#[derive(Subcommand)]
+pub enum BranchCommands {
+    /// List branches in a repository
+    List {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Filter expression, e.g. 'name ~ "feat"'
+        #[arg(short = 'q', long)]
+        query: Option<String>,
+
+        /// Sort field, prefix with '-' for descending, e.g. -target.date
+        #[arg(long)]
+        sort: Option<String>,
+
+        /// Number of results per page (max 100)
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+
+        /// Page number to fetch
+        #[arg(long)]
+        page: Option<u32>,
+    },
+
+    /// Create a branch
+    Create {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Name of the branch to create
+        name: String,
+
+        /// Commit hash or existing branch name to branch from (a 7-40 char hex value is treated as a commit hash)
+        #[arg(long, value_name = "HASH_OR_BRANCH")]
+        from: String,
+    },
+
+    /// View a single branch
+    View {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Branch name
+        name: String,
+    },
+
+    /// Delete a branch
+    Delete {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Branch name
+        name: String,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+}
+
+#[derive(Tabled)]
+struct BranchRow {
+    #[tabled(rename = "NAME")]
+    name: String,
+    #[tabled(rename = "COMMIT")]
+    commit: String,
+    #[tabled(rename = "AUTHOR")]
+    author: String,
+    #[tabled(rename = "DATE")]
+    date: String,
+    #[tabled(rename = "MESSAGE")]
+    message: String,
+}
+
+impl From<&BranchDetail> for BranchRow {
+    fn from(branch: &BranchDetail) -> Self {
+        let target = branch.target.as_ref();
+        BranchRow {
+            name: branch.name.clone(),
+            commit: target.map(|t| short_hash(&t.hash)).unwrap_or_default(),
+            author: target
+                .map(|t| author_label(t.author.as_ref()))
+                .unwrap_or_else(|| "-".to_string()),
+            date: target
+                .and_then(|t| t.date)
+                .map(|d| d.format("%Y-%m-%d").to_string())
+                .unwrap_or_default(),
+            message: target
+                .and_then(|t| t.message.as_deref())
+                .map(|m| first_line_truncated(m, MSG_WIDTH))
+                .unwrap_or_default(),
+        }
+    }
+}
+
+impl BranchCommands {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            BranchCommands::List {
+                repo,
+                query,
+                sort,
+                limit,
+                page,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let branches = client
+                    .list_branches_filtered(
+                        &workspace,
+                        &repo_slug,
+                        query.as_deref(),
+                        sort.as_deref(),
+                        page,
+                        Some(effective_limit(limit)),
+                    )
+                    .await?;
+
+                if output_json() {
+                    return print_json(&branches.values);
+                }
+
+                if branches.values.is_empty() {
+                    println!("No branches found in {}", repo);
+                    return Ok(());
+                }
+
+                let rows: Vec<BranchRow> = branches.values.iter().map(BranchRow::from).collect();
+                println!("{}", Table::new(rows));
+
+                if branches.next.is_some() {
+                    println!(
+                        "\n{} More branches available. Use --limit or --page to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
+                Ok(())
+            }
+
+            BranchCommands::Create { repo, name, from } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                // --from accepts either a commit hash or a branch name; the
+                // API only takes a hash, so resolve branch names first.
+                let target_hash = if looks_like_hash(&from) {
+                    from
+                } else {
+                    let source = client
+                        .get_branch(&workspace, &repo_slug, &from)
+                        .await
+                        .with_context(|| format!("Failed to resolve source branch '{}'", from))?;
+                    source
+                        .target
+                        .map(|t| t.hash)
+                        .with_context(|| format!("Branch '{}' has no target commit", from))?
+                };
+
+                let branch = client
+                    .create_branch(&workspace, &repo_slug, &name, &target_hash)
+                    .await?;
+
+                if output_json() {
+                    return print_json(&branch);
+                }
+
+                println!(
+                    "{} Created branch {} at {}",
+                    "✓".green(),
+                    branch.name.cyan(),
+                    short_hash(&target_hash)
+                );
+
+                Ok(())
+            }
+
+            BranchCommands::View { repo, name } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let branch = client.get_branch(&workspace, &repo_slug, &name).await?;
+
+                if output_json() {
+                    return print_json(&branch);
+                }
+
+                println!("{}", branch.name.bold());
+                println!("{}", "─".repeat(50));
+
+                if let Some(target) = &branch.target {
+                    println!("{} {}", "Commit:".dimmed(), target.hash);
+                    println!(
+                        "{} {}",
+                        "Author:".dimmed(),
+                        author_label(target.author.as_ref())
+                    );
+
+                    if let Some(date) = target.date {
+                        println!("{} {}", "Date:".dimmed(), date.format("%Y-%m-%d %H:%M:%S"));
+                    }
+
+                    if let Some(message) = &target.message {
+                        println!();
+                        println!("{}", message.trim_end());
+                    }
+                }
+
+                Ok(())
+            }
+
+            BranchCommands::Delete { repo, name, yes } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                if !yes
+                    && !confirm_or_abort(format!("Delete branch {} from {}?", name.red(), repo))?
+                {
+                    return Ok(());
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                client.delete_branch(&workspace, &repo_slug, &name).await?;
+
+                if output_json() {
+                    return print_json(&serde_json::json!({ "ok": true }));
+                }
+
+                println!("{} Deleted branch {}", "✓".green(), name);
+
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Whether `s` is plausibly an abbreviated or full commit hash:
+/// 7 to 40 hexadecimal characters.
+fn looks_like_hash(s: &str) -> bool {
+    (7..=40).contains(&s.len()) && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::looks_like_hash;
+
+    #[test]
+    fn looks_like_hash_accepts_abbreviated_and_full_hashes() {
+        assert!(looks_like_hash("deadbee"));
+        assert!(looks_like_hash("DEADBEE1"));
+        assert!(looks_like_hash(&"a".repeat(40)));
+    }
+
+    #[test]
+    fn looks_like_hash_rejects_wrong_lengths() {
+        assert!(!looks_like_hash("abc123")); // 6 chars: too short
+        assert!(!looks_like_hash(&"a".repeat(41))); // too long
+        assert!(!looks_like_hash(""));
+    }
+
+    #[test]
+    fn looks_like_hash_rejects_non_hex_names() {
+        assert!(!looks_like_hash("develop"));
+        assert!(!looks_like_hash("feature/x"));
+        assert!(!looks_like_hash("release-1.0"));
+    }
+}

--- a/src/cli/branch_restriction.rs
+++ b/src/cli/branch_restriction.rs
@@ -1,0 +1,172 @@
+use anyhow::Result;
+use clap::Subcommand;
+use colored::Colorize;
+use tabled::{Table, Tabled};
+
+use super::{confirm_or_abort, output_json, parse_repo, print_json};
+use crate::api::BitbucketClient;
+
+#[derive(Subcommand)]
+pub enum BranchRestrictionCommands {
+    /// List branch restriction rules on a repository
+    List {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Number of results per page (max 100)
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+    },
+
+    /// Create a branch restriction rule
+    Create {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Rule kind (e.g. push, force, delete, require_approvals_to_merge)
+        #[arg(long)]
+        kind: String,
+
+        /// Branch pattern the rule applies to (glob, e.g. main or release/*)
+        #[arg(long)]
+        pattern: String,
+
+        /// Numeric parameter for kinds that need one (e.g. required approval count)
+        #[arg(long, value_name = "N")]
+        value: Option<u64>,
+    },
+
+    /// Delete a branch restriction rule
+    Delete {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Rule id (shown by `branch-restriction list`)
+        id: u64,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+}
+
+#[derive(Tabled)]
+struct RestrictionRow {
+    #[tabled(rename = "ID")]
+    id: String,
+    #[tabled(rename = "KIND")]
+    kind: String,
+    #[tabled(rename = "PATTERN")]
+    pattern: String,
+    #[tabled(rename = "VALUE")]
+    value: String,
+}
+
+impl BranchRestrictionCommands {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            BranchRestrictionCommands::List { repo, limit } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let restrictions = client
+                    .list_branch_restrictions(&workspace, &repo_slug, Some(limit.clamp(1, 100)))
+                    .await?;
+
+                if output_json() {
+                    return print_json(&restrictions.values);
+                }
+
+                if restrictions.values.is_empty() {
+                    println!("No branch restrictions found in {}", repo);
+                    return Ok(());
+                }
+
+                let rows: Vec<RestrictionRow> = restrictions
+                    .values
+                    .iter()
+                    .map(|r| RestrictionRow {
+                        id: r.id.map(|id| id.to_string()).unwrap_or_default(),
+                        kind: r.kind.clone(),
+                        pattern: r.pattern.clone().unwrap_or_default(),
+                        value: r
+                            .value
+                            .map(|v| v.to_string())
+                            .unwrap_or_else(|| "-".to_string()),
+                    })
+                    .collect();
+
+                println!("{}", Table::new(rows));
+
+                if restrictions.next.is_some() {
+                    println!(
+                        "\n{} More branch restrictions available. Use --limit to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
+                Ok(())
+            }
+
+            BranchRestrictionCommands::Create {
+                repo,
+                kind,
+                pattern,
+                value,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let restriction = client
+                    .create_branch_restriction(&workspace, &repo_slug, &kind, &pattern, value)
+                    .await?;
+
+                if output_json() {
+                    return print_json(&restriction);
+                }
+
+                let id_label = restriction
+                    .id
+                    .map(|id| format!(" (id {})", id))
+                    .unwrap_or_default();
+
+                println!(
+                    "{} Created {} restriction on {} for pattern {}{}",
+                    "✓".green(),
+                    restriction.kind.cyan(),
+                    repo,
+                    restriction.pattern.as_deref().unwrap_or(&pattern).cyan(),
+                    id_label
+                );
+
+                Ok(())
+            }
+
+            BranchRestrictionCommands::Delete { repo, id, yes } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                if !yes
+                    && !confirm_or_abort(format!(
+                        "Delete branch restriction {} from {}?",
+                        id.to_string().red(),
+                        repo
+                    ))?
+                {
+                    return Ok(());
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                client
+                    .delete_branch_restriction(&workspace, &repo_slug, id)
+                    .await?;
+
+                if output_json() {
+                    return print_json(&serde_json::json!({ "ok": true }));
+                }
+
+                println!("{} Deleted branch restriction {}", "✓".green(), id);
+
+                Ok(())
+            }
+        }
+    }
+}

--- a/src/cli/branching_model.rs
+++ b/src/cli/branching_model.rs
@@ -1,0 +1,250 @@
+use anyhow::Result;
+use clap::Subcommand;
+use colored::Colorize;
+use tabled::{Table, Tabled};
+
+use super::{output_json, parse_repo, print_json};
+use crate::api::BitbucketClient;
+use crate::models::{BranchingModelBranchSettings, ModelBranch, UpdateBranchingModelRequest};
+
+/// Commands for viewing and configuring a repository's branching model.
+#[derive(Subcommand)]
+pub enum BranchingModelCommands {
+    /// View the repository's effective branching model
+    View {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+    },
+
+    /// Update the repository's branching model settings
+    Set {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Branch to use as the development branch
+        #[arg(long, value_name = "BRANCH")]
+        development: Option<String>,
+
+        /// Branch to use as the production branch (also enables it)
+        #[arg(long, value_name = "BRANCH")]
+        production: Option<String>,
+    },
+}
+
+#[derive(Tabled)]
+struct BranchTypeRow {
+    #[tabled(rename = "KIND")]
+    kind: String,
+    #[tabled(rename = "PREFIX")]
+    prefix: String,
+}
+
+impl BranchingModelCommands {
+    /// Execute the branching-model subcommand.
+    pub async fn run(self) -> Result<()> {
+        match self {
+            BranchingModelCommands::View { repo } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let model = client.get_branching_model(&workspace, &repo_slug).await?;
+
+                if output_json() {
+                    return print_json(&model);
+                }
+
+                println!("{}", format!("Branching model for {}", repo).bold());
+                println!("{}", "─".repeat(50));
+
+                println!(
+                    "{} {}",
+                    "Development:".dimmed(),
+                    describe_model_branch(model.development.as_ref())
+                );
+                println!(
+                    "{} {}",
+                    "Production:".dimmed(),
+                    describe_model_branch(model.production.as_ref())
+                );
+
+                match model.branch_types.as_deref() {
+                    Some(branch_types) if !branch_types.is_empty() => {
+                        println!();
+                        println!("{}", "Branch types:".bold());
+
+                        let rows: Vec<BranchTypeRow> = branch_types
+                            .iter()
+                            .map(|t| BranchTypeRow {
+                                kind: t.kind.clone().unwrap_or_else(|| "-".into()),
+                                prefix: t.prefix.clone().unwrap_or_else(|| "-".into()),
+                            })
+                            .collect();
+
+                        println!("{}", Table::new(rows));
+                    }
+                    _ => {
+                        println!();
+                        println!("No branch types configured");
+                    }
+                }
+
+                Ok(())
+            }
+
+            BranchingModelCommands::Set {
+                repo,
+                development,
+                production,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                let request = build_branching_model_update(development, production);
+                if request.is_empty() {
+                    anyhow::bail!("Nothing to update. Pass --development and/or --production.");
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                let updated = client
+                    .update_branching_model_settings(&workspace, &repo_slug, &request)
+                    .await?;
+
+                if output_json() {
+                    return print_json(&updated);
+                }
+
+                println!(
+                    "{} Updated branching model for {}",
+                    "✓".green(),
+                    repo.cyan()
+                );
+                println!(
+                    "{} {}",
+                    "Development:".dimmed(),
+                    describe_model_branch(updated.development.as_ref())
+                );
+                println!(
+                    "{} {}",
+                    "Production:".dimmed(),
+                    describe_model_branch(updated.production.as_ref())
+                );
+
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Build the settings update for `branching-model set` from its flags. A
+/// named branch implies `use_mainbranch: false` (the API ignores the name
+/// otherwise), and naming a production branch also enables it.
+fn build_branching_model_update(
+    development: Option<String>,
+    production: Option<String>,
+) -> UpdateBranchingModelRequest {
+    UpdateBranchingModelRequest {
+        development: development.map(|name| BranchingModelBranchSettings {
+            name: Some(name),
+            use_mainbranch: Some(false),
+            enabled: None,
+        }),
+        production: production.map(|name| BranchingModelBranchSettings {
+            name: Some(name),
+            use_mainbranch: Some(false),
+            enabled: Some(true),
+        }),
+    }
+}
+
+/// One-line description of a branching model branch: the resolved branch name
+/// when the model is effective, else the configured name, marking branches
+/// that track the repository's main branch.
+fn describe_model_branch(branch: Option<&ModelBranch>) -> String {
+    let Some(branch) = branch else {
+        return "(not set)".to_string();
+    };
+
+    let name = branch
+        .branch
+        .as_ref()
+        .map(|b| b.name.as_str())
+        .or(branch.name.as_deref());
+
+    match (name, branch.use_mainbranch.unwrap_or(false)) {
+        (Some(name), true) => format!("{} (main branch)", name),
+        (Some(name), false) => name.to_string(),
+        (None, true) => "(main branch)".to_string(),
+        (None, false) => "-".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::Branch;
+
+    #[test]
+    fn build_update_with_no_flags_is_empty() {
+        assert!(build_branching_model_update(None, None).is_empty());
+    }
+
+    #[test]
+    fn build_update_sets_development_branch_by_name() {
+        let request = build_branching_model_update(Some("develop".into()), None);
+
+        let development = request.development.expect("development should be set");
+        assert_eq!(development.name.as_deref(), Some("develop"));
+        assert_eq!(development.use_mainbranch, Some(false));
+        assert_eq!(development.enabled, None);
+        assert!(request.production.is_none());
+    }
+
+    #[test]
+    fn build_update_enables_production_branch() {
+        let request = build_branching_model_update(None, Some("release".into()));
+
+        let production = request.production.expect("production should be set");
+        assert_eq!(production.name.as_deref(), Some("release"));
+        assert_eq!(production.use_mainbranch, Some(false));
+        assert_eq!(production.enabled, Some(true));
+        assert!(request.development.is_none());
+    }
+
+    fn model_branch(
+        name: Option<&str>,
+        resolved: Option<&str>,
+        use_mainbranch: Option<bool>,
+    ) -> ModelBranch {
+        ModelBranch {
+            name: name.map(String::from),
+            branch: resolved.map(|n| Branch {
+                name: n.to_string(),
+                branch_type: None,
+            }),
+            use_mainbranch,
+        }
+    }
+
+    #[test]
+    fn describe_model_branch_prefers_resolved_branch_name() {
+        let branch = model_branch(Some("development"), Some("main"), Some(true));
+        assert_eq!(describe_model_branch(Some(&branch)), "main (main branch)");
+    }
+
+    #[test]
+    fn describe_model_branch_uses_configured_name_without_resolution() {
+        let branch = model_branch(Some("develop"), None, Some(false));
+        assert_eq!(describe_model_branch(Some(&branch)), "develop");
+    }
+
+    #[test]
+    fn describe_model_branch_handles_unnamed_mainbranch_tracking() {
+        let branch = model_branch(None, None, Some(true));
+        assert_eq!(describe_model_branch(Some(&branch)), "(main branch)");
+    }
+
+    #[test]
+    fn describe_model_branch_handles_missing_branch() {
+        assert_eq!(describe_model_branch(None), "(not set)");
+        let empty = model_branch(None, None, None);
+        assert_eq!(describe_model_branch(Some(&empty)), "-");
+    }
+}

--- a/src/cli/commit.rs
+++ b/src/cli/commit.rs
@@ -1,0 +1,258 @@
+use anyhow::Result;
+use clap::Subcommand;
+use colored::Colorize;
+use tabled::{Table, Tabled};
+
+use super::{output_json, parse_repo, print_json};
+use crate::api::BitbucketClient;
+use crate::cli::pagination::effective_limit;
+use crate::models::CommitAuthor;
+
+/// Width of the truncated commit-message column in list tables.
+const MSG_WIDTH: usize = 50;
+
+#[derive(Subcommand)]
+pub enum CommitCommands {
+    /// List commits in a repository
+    List {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Branch, tag, or commit hash to list history from (default: the repository's main branch)
+        #[arg(short = 'r', long = "ref", value_name = "REF")]
+        git_ref: Option<String>,
+
+        /// Number of results per page (max 100)
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+
+        /// Page number to fetch
+        #[arg(long)]
+        page: Option<u32>,
+    },
+
+    /// View a single commit
+    View {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Commit hash (full or abbreviated)
+        hash: String,
+    },
+
+    /// Show the raw diff for a commit or revision spec
+    Diff {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// A commit (diffed against its first parent) or a source..destination revision spec
+        spec: String,
+    },
+}
+
+#[derive(Tabled)]
+struct CommitRow {
+    #[tabled(rename = "HASH")]
+    hash: String,
+    #[tabled(rename = "AUTHOR")]
+    author: String,
+    #[tabled(rename = "DATE")]
+    date: String,
+    #[tabled(rename = "MESSAGE")]
+    message: String,
+}
+
+impl CommitCommands {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            CommitCommands::List {
+                repo,
+                git_ref,
+                limit,
+                page,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let commits = client
+                    .list_commits(
+                        &workspace,
+                        &repo_slug,
+                        git_ref.as_deref(),
+                        page,
+                        Some(effective_limit(limit)),
+                    )
+                    .await?;
+
+                if output_json() {
+                    return print_json(&commits.values);
+                }
+
+                if commits.values.is_empty() {
+                    println!("No commits found in {}", repo);
+                    return Ok(());
+                }
+
+                let rows: Vec<CommitRow> = commits
+                    .values
+                    .iter()
+                    .map(|c| CommitRow {
+                        hash: short_hash(&c.hash),
+                        author: author_label(c.author.as_ref()),
+                        date: c
+                            .date
+                            .map(|d| d.format("%Y-%m-%d").to_string())
+                            .unwrap_or_default(),
+                        message: first_line_truncated(
+                            c.message.as_deref().unwrap_or(""),
+                            MSG_WIDTH,
+                        ),
+                    })
+                    .collect();
+
+                println!("{}", Table::new(rows));
+
+                if commits.next.is_some() {
+                    println!(
+                        "\n{} More commits available. Use --limit or --page to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
+                Ok(())
+            }
+
+            CommitCommands::View { repo, hash } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let commit = client.get_commit(&workspace, &repo_slug, &hash).await?;
+
+                if output_json() {
+                    return print_json(&commit);
+                }
+
+                println!("{}", commit.hash.bold());
+                println!("{}", "─".repeat(50));
+                println!(
+                    "{} {}",
+                    "Author:".dimmed(),
+                    author_label(commit.author.as_ref())
+                );
+
+                if let Some(date) = commit.date {
+                    println!("{} {}", "Date:".dimmed(), date.format("%Y-%m-%d %H:%M:%S"));
+                }
+
+                if let Some(message) = &commit.message {
+                    println!();
+                    println!("{}", message.trim_end());
+                }
+
+                Ok(())
+            }
+
+            CommitCommands::Diff { repo, spec } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let diff = client.get_diff(&workspace, &repo_slug, &spec).await?;
+
+                print!("{}", diff);
+
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Abbreviate a commit hash to the conventional 7 characters.
+pub(crate) fn short_hash(hash: &str) -> String {
+    hash.chars().take(7).collect()
+}
+
+/// First line of a commit message, truncated to at most `max` characters.
+pub(crate) fn first_line_truncated(message: &str, max: usize) -> String {
+    message
+        .lines()
+        .next()
+        .unwrap_or("")
+        .chars()
+        .take(max)
+        .collect()
+}
+
+/// Human-readable author: the account display name when the author maps to a
+/// Bitbucket user, otherwise the raw `Name <email>` signature, otherwise "-".
+pub(crate) fn author_label(author: Option<&CommitAuthor>) -> String {
+    author
+        .and_then(|a| {
+            a.user
+                .as_ref()
+                .map(|u| u.display_name.clone())
+                .or_else(|| a.raw.clone())
+        })
+        .unwrap_or_else(|| "-".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_hash_abbreviates_to_seven_chars() {
+        assert_eq!(short_hash("deadbeefcafe1234"), "deadbee");
+    }
+
+    #[test]
+    fn short_hash_keeps_already_short_input() {
+        assert_eq!(short_hash("abc12"), "abc12");
+    }
+
+    #[test]
+    fn first_line_truncated_takes_first_line() {
+        assert_eq!(
+            first_line_truncated("feat: add login\n\nLong body here", 60),
+            "feat: add login"
+        );
+    }
+
+    #[test]
+    fn first_line_truncated_caps_length() {
+        assert_eq!(first_line_truncated("abcdefghij", 4), "abcd");
+    }
+
+    #[test]
+    fn first_line_truncated_handles_empty_message() {
+        assert_eq!(first_line_truncated("", 60), "");
+    }
+
+    #[test]
+    fn author_label_prefers_user_display_name_over_raw() {
+        let author = CommitAuthor {
+            raw: Some("Jo <jo@example.com>".to_string()),
+            user: Some(crate::models::User {
+                uuid: "{user-uuid}".to_string(),
+                username: None,
+                display_name: "Jo Bloggs".to_string(),
+                account_id: None,
+                user_type: "user".to_string(),
+                links: None,
+            }),
+        };
+        assert_eq!(author_label(Some(&author)), "Jo Bloggs");
+    }
+
+    #[test]
+    fn author_label_falls_back_to_raw_then_dash() {
+        let raw_only = CommitAuthor {
+            raw: Some("Jo <jo@example.com>".to_string()),
+            user: None,
+        };
+        assert_eq!(author_label(Some(&raw_only)), "Jo <jo@example.com>");
+
+        let empty = CommitAuthor {
+            raw: None,
+            user: None,
+        };
+        assert_eq!(author_label(Some(&empty)), "-");
+        assert_eq!(author_label(None), "-");
+    }
+}

--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -1,0 +1,692 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::{Subcommand, ValueEnum};
+use colored::Colorize;
+use tabled::{Table, Tabled};
+
+use super::{confirm_or_abort, output_json, parse_repo, print_json};
+use crate::api::BitbucketClient;
+use crate::cli::pagination::{MAX_LIMIT, effective_limit as capped_limit};
+use crate::models::{
+    AddDeployKeyRequest, CreateEnvironmentRequest, Deployment, Environment, EnvironmentType,
+};
+
+/// How many characters of SSH key material to show in list tables.
+const KEY_DISPLAY_CHARS: usize = 40;
+
+/// Commands for managing repository deploy keys.
+#[derive(Subcommand)]
+pub enum DeployKeyCommands {
+    /// List deploy keys for a repository
+    List {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+    },
+
+    /// Add a deploy key to a repository
+    Add {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// SSH public key material (e.g. "ssh-ed25519 AAAA... user@host")
+        #[arg(
+            long,
+            conflicts_with = "key_file",
+            required_unless_present = "key_file"
+        )]
+        key: Option<String>,
+
+        /// Read the SSH public key from a file
+        #[arg(long, value_name = "PATH", required_unless_present = "key")]
+        key_file: Option<PathBuf>,
+
+        /// Label for the deploy key
+        #[arg(long)]
+        label: String,
+    },
+
+    /// Delete a deploy key from a repository
+    Delete {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Deploy key ID (see `deploy-key list`)
+        id: u64,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+}
+
+/// Commands for managing deployment environments.
+#[derive(Subcommand)]
+pub enum EnvironmentCommands {
+    /// List deployment environments for a repository
+    List {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+    },
+
+    /// Create a deployment environment
+    Create {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Environment name
+        name: String,
+
+        /// Environment type
+        #[arg(
+            long = "type",
+            value_name = "TYPE",
+            value_enum,
+            ignore_case = true,
+            default_value = "test"
+        )]
+        environment_type: EnvironmentTypeArg,
+    },
+
+    /// Delete a deployment environment
+    Delete {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Environment UUID (see `environment list`)
+        uuid: String,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+}
+
+/// Commands for inspecting deployments.
+#[derive(Subcommand)]
+pub enum DeploymentCommands {
+    /// List deployments for a repository
+    List {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Number of results (max 100)
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+    },
+
+    /// View deployment details
+    View {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Deployment UUID
+        uuid: String,
+    },
+}
+
+/// Environment category accepted by `environment create --type`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum EnvironmentTypeArg {
+    Test,
+    Staging,
+    Production,
+}
+
+impl EnvironmentTypeArg {
+    /// The type name the Bitbucket API expects for this environment category.
+    fn api_name(self) -> &'static str {
+        match self {
+            EnvironmentTypeArg::Test => "Test",
+            EnvironmentTypeArg::Staging => "Staging",
+            EnvironmentTypeArg::Production => "Production",
+        }
+    }
+}
+
+#[derive(Tabled)]
+struct DeployKeyRow {
+    #[tabled(rename = "ID")]
+    id: String,
+    #[tabled(rename = "LABEL")]
+    label: String,
+    #[tabled(rename = "KEY")]
+    key: String,
+}
+
+impl DeployKeyCommands {
+    /// Execute the deploy-key subcommand.
+    pub async fn run(self) -> Result<()> {
+        match self {
+            DeployKeyCommands::List { repo } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let keys = client.list_deploy_keys(&workspace, &repo_slug).await?;
+
+                if output_json() {
+                    return print_json(&keys.values);
+                }
+
+                if keys.values.is_empty() {
+                    println!("No deploy keys found in {}", repo);
+                    return Ok(());
+                }
+
+                let rows: Vec<DeployKeyRow> = keys
+                    .values
+                    .iter()
+                    .map(|k| DeployKeyRow {
+                        id: k.id.map(|id| id.to_string()).unwrap_or_else(|| "-".into()),
+                        label: k.label.clone().unwrap_or_default(),
+                        key: truncate_chars(k.key.as_deref().unwrap_or("-"), KEY_DISPLAY_CHARS),
+                    })
+                    .collect();
+
+                println!("{}", Table::new(rows));
+
+                Ok(())
+            }
+
+            DeployKeyCommands::Add {
+                repo,
+                key,
+                key_file,
+                label,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                // clap enforces exactly one key source; the bail arms are a
+                // safety net in case this is ever called programmatically.
+                let material = match (key, key_file) {
+                    (Some(key), None) => key,
+                    (None, Some(path)) => std::fs::read_to_string(&path)
+                        .with_context(|| format!("Failed to read key file '{}'", path.display()))?,
+                    (Some(_), Some(_)) => {
+                        anyhow::bail!("Pass either --key or --key-file, not both")
+                    }
+                    (None, None) => anyhow::bail!("Pass one of --key or --key-file"),
+                };
+                let key = normalize_key(&material)?;
+
+                let request = AddDeployKeyRequest { key, label };
+
+                let client = BitbucketClient::from_stored().await?;
+                let added = client
+                    .add_deploy_key(&workspace, &repo_slug, &request)
+                    .await?;
+
+                if output_json() {
+                    return print_json(&added);
+                }
+
+                println!(
+                    "{} Added deploy key {} to {}",
+                    "✓".green(),
+                    added.label.as_deref().unwrap_or(&request.label).cyan(),
+                    repo.cyan()
+                );
+
+                if let Some(id) = added.id {
+                    println!("{} {}", "ID:".dimmed(), id);
+                }
+
+                Ok(())
+            }
+
+            DeployKeyCommands::Delete { repo, id, yes } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                if !yes
+                    && !confirm_or_abort(format!(
+                        "Delete deploy key {} from {}?",
+                        id.to_string().red(),
+                        repo
+                    ))?
+                {
+                    return Ok(());
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                client.delete_deploy_key(&workspace, &repo_slug, id).await?;
+
+                if output_json() {
+                    return print_json(&serde_json::json!({ "ok": true }));
+                }
+
+                println!("{} Deleted deploy key {}", "✓".green(), id);
+
+                Ok(())
+            }
+        }
+    }
+}
+
+#[derive(Tabled)]
+struct EnvironmentRow {
+    #[tabled(rename = "NAME")]
+    name: String,
+    #[tabled(rename = "TYPE")]
+    environment_type: String,
+    #[tabled(rename = "UUID")]
+    uuid: String,
+}
+
+impl EnvironmentCommands {
+    /// Execute the environment subcommand.
+    pub async fn run(self) -> Result<()> {
+        match self {
+            EnvironmentCommands::List { repo } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let environments = client.list_environments(&workspace, &repo_slug).await?;
+
+                if output_json() {
+                    return print_json(&environments.values);
+                }
+
+                if environments.values.is_empty() {
+                    println!("No environments found in {}", repo);
+                    return Ok(());
+                }
+
+                let rows: Vec<EnvironmentRow> = environments
+                    .values
+                    .iter()
+                    .map(|e| EnvironmentRow {
+                        name: e.name.clone().unwrap_or_default(),
+                        environment_type: e
+                            .environment_type
+                            .as_ref()
+                            .and_then(|t| t.name.clone())
+                            .unwrap_or_else(|| "-".into()),
+                        uuid: e.uuid.clone().unwrap_or_else(|| "-".into()),
+                    })
+                    .collect();
+
+                println!("{}", Table::new(rows));
+
+                Ok(())
+            }
+
+            EnvironmentCommands::Create {
+                repo,
+                name,
+                environment_type,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                let request = CreateEnvironmentRequest {
+                    name,
+                    environment_type: EnvironmentType {
+                        name: Some(environment_type.api_name().to_string()),
+                    },
+                };
+
+                let client = BitbucketClient::from_stored().await?;
+                let created = client
+                    .create_environment(&workspace, &repo_slug, &request)
+                    .await?;
+
+                if output_json() {
+                    return print_json(&created);
+                }
+
+                println!(
+                    "{} Created {} environment {}",
+                    "✓".green(),
+                    environment_type.api_name(),
+                    created.name.as_deref().unwrap_or(&request.name).cyan()
+                );
+
+                if let Some(uuid) = &created.uuid {
+                    println!("{} {}", "UUID:".dimmed(), uuid);
+                }
+
+                Ok(())
+            }
+
+            EnvironmentCommands::Delete { repo, uuid, yes } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let uuid = ensure_braced(&uuid);
+
+                if !yes
+                    && !confirm_or_abort(format!(
+                        "Delete environment {} from {}?",
+                        uuid.red(),
+                        repo
+                    ))?
+                {
+                    return Ok(());
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                client
+                    .delete_environment(&workspace, &repo_slug, &uuid)
+                    .await?;
+
+                if output_json() {
+                    return print_json(&serde_json::json!({ "ok": true }));
+                }
+
+                println!("{} Deleted environment {}", "✓".green(), uuid);
+
+                Ok(())
+            }
+        }
+    }
+}
+
+#[derive(Tabled)]
+struct DeploymentRow {
+    #[tabled(rename = "UUID")]
+    uuid: String,
+    #[tabled(rename = "STATUS")]
+    status: String,
+    #[tabled(rename = "ENVIRONMENT")]
+    environment: String,
+}
+
+impl DeploymentCommands {
+    /// Execute the deployment subcommand.
+    pub async fn run(self) -> Result<()> {
+        match self {
+            DeploymentCommands::List { repo, limit } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                let capped = capped_limit(limit);
+                if capped != limit && !output_json() {
+                    println!(
+                        "{} Limit capped at {} (the Bitbucket API maximum)",
+                        "ℹ".blue(),
+                        MAX_LIMIT
+                    );
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                let deployments = client
+                    .list_deployments(&workspace, &repo_slug, Some(capped))
+                    .await?;
+
+                if output_json() {
+                    return print_json(&deployments.values);
+                }
+
+                if deployments.values.is_empty() {
+                    println!("No deployments found in {}", repo);
+                    return Ok(());
+                }
+
+                let rows: Vec<DeploymentRow> = deployments
+                    .values
+                    .iter()
+                    .map(|d| DeploymentRow {
+                        uuid: d.uuid.clone().unwrap_or_else(|| "-".into()),
+                        status: color_status(&deployment_status(d)),
+                        environment: environment_label(d.environment.as_ref()),
+                    })
+                    .collect();
+
+                println!("{}", Table::new(rows));
+
+                if deployments.next.is_some() {
+                    println!(
+                        "\n{} More deployments available. Use --limit to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
+                Ok(())
+            }
+
+            DeploymentCommands::View { repo, uuid } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let uuid = ensure_braced(&uuid);
+
+                let client = BitbucketClient::from_stored().await?;
+                let deployment = client.get_deployment(&workspace, &repo_slug, &uuid).await?;
+
+                if output_json() {
+                    return print_json(&deployment);
+                }
+
+                println!(
+                    "{}",
+                    format!("Deployment {}", deployment.uuid.as_deref().unwrap_or(&uuid)).bold()
+                );
+                println!("{}", "─".repeat(60));
+
+                println!(
+                    "{} {}",
+                    "Status:".dimmed(),
+                    color_status(&deployment_status(&deployment))
+                );
+                println!(
+                    "{} {}",
+                    "Environment:".dimmed(),
+                    environment_label(deployment.environment.as_ref())
+                );
+
+                if let Some(summary) = deployment.release.as_ref().and_then(release_summary) {
+                    println!("{} {}", "Release:".dimmed(), summary);
+                }
+
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Trim surrounding whitespace from SSH key material (public keys are a
+/// single line; files usually end with a newline), rejecting empty input.
+fn normalize_key(material: &str) -> Result<String> {
+    let key = material.trim();
+    if key.is_empty() {
+        anyhow::bail!("The provided SSH key is empty");
+    }
+    Ok(key.to_string())
+}
+
+/// Truncate a string to at most `max` characters, appending an ellipsis when
+/// anything was cut off.
+fn truncate_chars(s: &str, max: usize) -> String {
+    let mut out: String = s.chars().take(max).collect();
+    if s.chars().count() > max {
+        out.push('…');
+    }
+    out
+}
+
+/// Wrap a UUID in the braces Bitbucket expects (`{...}`) unless it already
+/// has them, so users can paste UUIDs with or without braces.
+fn ensure_braced(uuid: &str) -> String {
+    let uuid = uuid.trim();
+    if uuid.starts_with('{') && uuid.ends_with('}') && uuid.len() >= 2 {
+        uuid.to_string()
+    } else {
+        format!("{{{}}}", uuid)
+    }
+}
+
+/// The most specific status string available for a deployment: the nested
+/// status name when present, then the state name, then "-".
+fn deployment_status(deployment: &Deployment) -> String {
+    deployment
+        .state
+        .as_ref()
+        .and_then(|state| {
+            state
+                .status
+                .as_ref()
+                .and_then(|status| status.get("name"))
+                .and_then(|name| name.as_str())
+                .map(str::to_string)
+                .or_else(|| state.name.clone())
+        })
+        .unwrap_or_else(|| "-".to_string())
+}
+
+/// Human-readable label for a deployment's environment: its name when known,
+/// falling back to the UUID, then "-".
+fn environment_label(environment: Option<&Environment>) -> String {
+    environment
+        .and_then(|e| e.name.clone().or_else(|| e.uuid.clone()))
+        .unwrap_or_else(|| "-".to_string())
+}
+
+/// Short summary of a deployment release: its name and, when present, the
+/// abbreviated commit hash it points at.
+fn release_summary(release: &serde_json::Value) -> Option<String> {
+    let name = release.get("name").and_then(|v| v.as_str());
+    let commit = release
+        .get("commit")
+        .and_then(|c| c.get("hash"))
+        .and_then(|h| h.as_str())
+        .map(|h| h.chars().take(12).collect::<String>());
+
+    match (name, commit) {
+        (Some(name), Some(commit)) => Some(format!("{} ({})", name, commit)),
+        (Some(name), None) => Some(name.to_string()),
+        (None, Some(commit)) => Some(commit),
+        (None, None) => None,
+    }
+}
+
+/// Colorize a deployment status string for terminal output.
+fn color_status(status: &str) -> String {
+    match status {
+        "COMPLETED" | "SUCCESSFUL" => status.green().to_string(),
+        "FAILED" | "ERROR" | "STOPPED" => status.red().to_string(),
+        "IN_PROGRESS" => status.blue().to_string(),
+        "PENDING" | "UNDEPLOYED" => status.dimmed().to_string(),
+        _ => status.normal().to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::models::DeploymentState;
+
+    #[test]
+    fn normalize_key_trims_surrounding_whitespace() {
+        let key = normalize_key("  ssh-ed25519 AAAA host\n").unwrap();
+        assert_eq!(key, "ssh-ed25519 AAAA host");
+    }
+
+    #[test]
+    fn normalize_key_rejects_empty_input() {
+        assert!(normalize_key("").is_err());
+        assert!(normalize_key("  \n\t ").is_err());
+    }
+
+    #[test]
+    fn truncate_chars_leaves_short_strings_alone() {
+        assert_eq!(truncate_chars("short", 40), "short");
+        assert_eq!(truncate_chars("1234567890", 10), "1234567890");
+    }
+
+    #[test]
+    fn truncate_chars_cuts_long_strings_with_ellipsis() {
+        assert_eq!(truncate_chars("abcdef", 3), "abc…");
+    }
+
+    #[test]
+    fn truncate_chars_counts_characters_not_bytes() {
+        assert_eq!(truncate_chars("ééééé", 3), "ééé…");
+    }
+
+    #[test]
+    fn ensure_braced_wraps_bare_uuids() {
+        assert_eq!(ensure_braced("abc-123"), "{abc-123}");
+    }
+
+    #[test]
+    fn ensure_braced_keeps_existing_braces() {
+        assert_eq!(ensure_braced("{abc-123}"), "{abc-123}");
+    }
+
+    #[test]
+    fn ensure_braced_trims_whitespace() {
+        assert_eq!(ensure_braced(" abc "), "{abc}");
+        assert_eq!(ensure_braced(" {abc} "), "{abc}");
+    }
+
+    #[test]
+    fn environment_type_arg_maps_to_api_names() {
+        assert_eq!(EnvironmentTypeArg::Test.api_name(), "Test");
+        assert_eq!(EnvironmentTypeArg::Staging.api_name(), "Staging");
+        assert_eq!(EnvironmentTypeArg::Production.api_name(), "Production");
+    }
+
+    fn deployment_with_state(state: Option<DeploymentState>) -> Deployment {
+        Deployment {
+            uuid: None,
+            state,
+            environment: None,
+            release: None,
+        }
+    }
+
+    #[test]
+    fn deployment_status_prefers_nested_status_name() {
+        let deployment = deployment_with_state(Some(DeploymentState {
+            name: Some("COMPLETED".into()),
+            status: Some(json!({ "name": "SUCCESSFUL" })),
+        }));
+        assert_eq!(deployment_status(&deployment), "SUCCESSFUL");
+    }
+
+    #[test]
+    fn deployment_status_falls_back_to_state_name() {
+        let deployment = deployment_with_state(Some(DeploymentState {
+            name: Some("IN_PROGRESS".into()),
+            status: None,
+        }));
+        assert_eq!(deployment_status(&deployment), "IN_PROGRESS");
+    }
+
+    #[test]
+    fn deployment_status_defaults_to_dash() {
+        assert_eq!(deployment_status(&deployment_with_state(None)), "-");
+    }
+
+    #[test]
+    fn environment_label_prefers_name_over_uuid() {
+        let environment = Environment {
+            uuid: Some("{u}".into()),
+            name: Some("Production".into()),
+            environment_type: None,
+        };
+        assert_eq!(environment_label(Some(&environment)), "Production");
+
+        let unnamed = Environment {
+            uuid: Some("{u}".into()),
+            name: None,
+            environment_type: None,
+        };
+        assert_eq!(environment_label(Some(&unnamed)), "{u}");
+
+        assert_eq!(environment_label(None), "-");
+    }
+
+    #[test]
+    fn release_summary_combines_name_and_short_hash() {
+        let release = json!({
+            "name": "v1.2.3",
+            "commit": { "hash": "0123456789abcdef0123" }
+        });
+        assert_eq!(release_summary(&release).unwrap(), "v1.2.3 (0123456789ab)");
+    }
+
+    #[test]
+    fn release_summary_handles_partial_data() {
+        assert_eq!(release_summary(&json!({ "name": "v1" })).unwrap(), "v1");
+        assert_eq!(
+            release_summary(&json!({ "commit": { "hash": "abc123" } })).unwrap(),
+            "abc123"
+        );
+        assert!(release_summary(&json!({})).is_none());
+    }
+}

--- a/src/cli/file.rs
+++ b/src/cli/file.rs
@@ -1,0 +1,273 @@
+use std::io::Write;
+
+use anyhow::Result;
+use clap::Subcommand;
+use colored::Colorize;
+use tabled::{Table, Tabled};
+
+use super::commit::{author_label, first_line_truncated, short_hash};
+use super::{output_json, parse_repo, print_json};
+use crate::api::BitbucketClient;
+use crate::cli::pagination::{effective_limit, format_size};
+
+/// Width of the truncated commit-message column in list tables.
+const MSG_WIDTH: usize = 50;
+
+#[derive(Subcommand)]
+pub enum FileCommands {
+    /// List files and directories in a repository
+    Ls {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Directory path to list (default: repository root)
+        #[arg(default_value = "")]
+        path: String,
+
+        /// Branch, tag, or commit hash (default: the repository's main branch)
+        #[arg(short = 'r', long = "ref", value_name = "REF")]
+        git_ref: Option<String>,
+
+        /// Number of results per page (max 100)
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+    },
+
+    /// Print the raw contents of a file
+    Cat {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// File path within the repository
+        path: String,
+
+        /// Branch, tag, or commit hash (default: the repository's main branch)
+        #[arg(short = 'r', long = "ref", value_name = "REF")]
+        git_ref: Option<String>,
+    },
+
+    /// List the commits that touched a file
+    History {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// File path within the repository
+        path: String,
+
+        /// Branch, tag, or commit hash to start from (default: the repository's main branch)
+        #[arg(short = 'r', long = "ref", value_name = "REF")]
+        git_ref: Option<String>,
+
+        /// Number of results per page (max 100)
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+    },
+}
+
+#[derive(Tabled)]
+struct SourceRow {
+    #[tabled(rename = "TYPE")]
+    entry_type: String,
+    #[tabled(rename = "SIZE")]
+    size: String,
+    #[tabled(rename = "PATH")]
+    path: String,
+}
+
+#[derive(Tabled)]
+struct HistoryRow {
+    #[tabled(rename = "COMMIT")]
+    commit: String,
+    #[tabled(rename = "AUTHOR")]
+    author: String,
+    #[tabled(rename = "DATE")]
+    date: String,
+    #[tabled(rename = "MESSAGE")]
+    message: String,
+}
+
+impl FileCommands {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            FileCommands::Ls {
+                repo,
+                path,
+                git_ref,
+                limit,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let git_ref = resolve_ref(&client, &workspace, &repo_slug, git_ref).await?;
+
+                let entries = client
+                    .list_source(
+                        &workspace,
+                        &repo_slug,
+                        &git_ref,
+                        &path,
+                        None,
+                        Some(effective_limit(limit)),
+                    )
+                    .await?;
+
+                if output_json() {
+                    return print_json(&entries.values);
+                }
+
+                if entries.values.is_empty() {
+                    println!("No entries found at '{}' in {} ({})", path, repo, git_ref);
+                    return Ok(());
+                }
+
+                let rows: Vec<SourceRow> = entries
+                    .values
+                    .iter()
+                    .map(|e| SourceRow {
+                        entry_type: entry_type_label(&e.entry_type).to_string(),
+                        size: e.size.map(format_size).unwrap_or_else(|| "-".to_string()),
+                        path: e.path.clone(),
+                    })
+                    .collect();
+
+                println!("{}", Table::new(rows));
+
+                if entries.next.is_some() {
+                    println!(
+                        "\n{} More entries available. Use --limit to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
+                Ok(())
+            }
+
+            FileCommands::Cat {
+                repo,
+                path,
+                git_ref,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let git_ref = resolve_ref(&client, &workspace, &repo_slug, git_ref).await?;
+
+                let content = client
+                    .get_file_raw(&workspace, &repo_slug, &git_ref, &path)
+                    .await?;
+
+                // Emit the file verbatim: no added trailing newline, and no
+                // table/color decoration, so output is pipe-friendly.
+                print!("{}", content);
+                std::io::stdout().flush()?;
+
+                Ok(())
+            }
+
+            FileCommands::History {
+                repo,
+                path,
+                git_ref,
+                limit,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let git_ref = resolve_ref(&client, &workspace, &repo_slug, git_ref).await?;
+
+                let history = client
+                    .get_file_history(
+                        &workspace,
+                        &repo_slug,
+                        &git_ref,
+                        &path,
+                        Some(effective_limit(limit)),
+                    )
+                    .await?;
+
+                if output_json() {
+                    return print_json(&history.values);
+                }
+
+                if history.values.is_empty() {
+                    println!("No history found for '{}' in {} ({})", path, repo, git_ref);
+                    return Ok(());
+                }
+
+                let rows: Vec<HistoryRow> = history
+                    .values
+                    .iter()
+                    .map(|entry| {
+                        let commit = entry.commit.as_ref();
+                        HistoryRow {
+                            commit: commit.map(|c| short_hash(&c.hash)).unwrap_or_default(),
+                            author: commit
+                                .map(|c| author_label(c.author.as_ref()))
+                                .unwrap_or_else(|| "-".to_string()),
+                            date: commit
+                                .and_then(|c| c.date)
+                                .map(|d| d.format("%Y-%m-%d").to_string())
+                                .unwrap_or_default(),
+                            message: commit
+                                .and_then(|c| c.message.as_deref())
+                                .map(|m| first_line_truncated(m, MSG_WIDTH))
+                                .unwrap_or_default(),
+                        }
+                    })
+                    .collect();
+
+                println!("{}", Table::new(rows));
+
+                if history.next.is_some() {
+                    println!(
+                        "\n{} More history available. Use --limit to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Resolve the ref to browse: an explicit --ref wins; otherwise the
+/// repository's configured main branch, falling back to "main".
+async fn resolve_ref(
+    client: &BitbucketClient,
+    workspace: &str,
+    repo_slug: &str,
+    git_ref: Option<String>,
+) -> Result<String> {
+    if let Some(r) = git_ref {
+        return Ok(r);
+    }
+
+    let repository = client.get_repository(workspace, repo_slug).await?;
+    Ok(repository
+        .mainbranch
+        .map(|b| b.name)
+        .unwrap_or_else(|| "main".to_string()))
+}
+
+/// Map Bitbucket's source entry types to short labels for the TYPE column.
+fn entry_type_label(entry_type: &str) -> &str {
+    match entry_type {
+        "commit_file" => "file",
+        "commit_directory" => "dir",
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entry_type_label_maps_known_types() {
+        assert_eq!(entry_type_label("commit_file"), "file");
+        assert_eq!(entry_type_label("commit_directory"), "dir");
+    }
+
+    #[test]
+    fn entry_type_label_passes_through_unknown_types() {
+        assert_eq!(entry_type_label("commit_submodule"), "commit_submodule");
+    }
+}

--- a/src/cli/issue.rs
+++ b/src/cli/issue.rs
@@ -1,12 +1,19 @@
-use anyhow::Result;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
 use clap::{Subcommand, ValueEnum};
 use colored::Colorize;
 use tabled::{Table, Tabled};
 
-use super::parse_repo;
+use super::{confirm_or_abort, parse_repo};
 use crate::api::BitbucketClient;
+use crate::api::issues::{IssueListFilters, IssueUpdate};
+use crate::cli::pagination::{MAX_LIMIT, effective_limit as capped_limit};
 use crate::models::{
-    CreateIssueRequest, IssueContentRequest, IssueKind, IssuePriority, IssueState,
+    ComponentName, CreateIssueRequest, IssueAttachment, IssueChange, IssueComment,
+    IssueContentRequest, IssueKind, IssueMetaItem, IssuePriority, IssueState, MilestoneName,
+    UserAccountId, VersionName,
 };
 
 #[derive(Subcommand)]
@@ -20,7 +27,35 @@ pub enum IssueCommands {
         #[arg(short, long, value_enum)]
         state: Option<IssueStateArg>,
 
-        /// Number of results
+        /// Filter by kind
+        #[arg(short, long, value_enum)]
+        kind: Option<IssueKindArg>,
+
+        /// Filter by priority
+        #[arg(short, long, value_enum)]
+        priority: Option<IssuePriorityArg>,
+
+        /// Filter by assignee account id
+        #[arg(long)]
+        assignee: Option<String>,
+
+        /// Filter by reporter account id
+        #[arg(long)]
+        reporter: Option<String>,
+
+        /// Raw BBQL query (overrides the individual filter flags)
+        #[arg(short, long)]
+        query: Option<String>,
+
+        /// Sort field, e.g. "-updated_on"
+        #[arg(long)]
+        sort: Option<String>,
+
+        /// Page number
+        #[arg(long)]
+        page: Option<u32>,
+
+        /// Number of results (capped at 100)
         #[arg(short, long, default_value = "25")]
         limit: u32,
     },
@@ -33,12 +68,17 @@ pub enum IssueCommands {
         /// Issue ID
         id: u64,
 
+        /// Also show the issue's comments
+        #[arg(short, long)]
+        comments: bool,
+
         /// Open in browser
         #[arg(short, long)]
         web: bool,
     },
 
     /// Create a new issue
+    #[command(disable_version_flag = true)]
     Create {
         /// Repository in format workspace/repo-slug
         repo: String,
@@ -58,6 +98,68 @@ pub enum IssueCommands {
         /// Issue priority
         #[arg(short, long, value_enum, default_value = "major")]
         priority: IssuePriorityArg,
+
+        /// Assignee account id
+        #[arg(short, long)]
+        assignee: Option<String>,
+
+        /// Component name
+        #[arg(short, long)]
+        component: Option<String>,
+
+        /// Milestone name
+        #[arg(short, long)]
+        milestone: Option<String>,
+
+        /// Version name
+        #[arg(long)]
+        version: Option<String>,
+    },
+
+    /// Edit an issue's fields
+    Edit {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Issue ID
+        id: u64,
+
+        /// New title
+        #[arg(short, long)]
+        title: Option<String>,
+
+        /// New description
+        #[arg(short = 'b', long)]
+        body: Option<String>,
+
+        /// New kind
+        #[arg(short, long, value_enum)]
+        kind: Option<IssueKindArg>,
+
+        /// New priority
+        #[arg(short, long, value_enum)]
+        priority: Option<IssuePriorityArg>,
+
+        /// New assignee account id
+        #[arg(short, long)]
+        assignee: Option<String>,
+
+        /// New state
+        #[arg(short, long, value_enum)]
+        state: Option<IssueStateArg>,
+    },
+
+    /// Delete an issue
+    Delete {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Issue ID
+        id: u64,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
     },
 
     /// Add a comment to an issue
@@ -71,6 +173,124 @@ pub enum IssueCommands {
         /// Comment text
         #[arg(short, long)]
         body: String,
+    },
+
+    /// List comments on an issue
+    Comments {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Issue ID
+        id: u64,
+
+        /// Number of results (capped at 100)
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+    },
+
+    /// Edit a comment on an issue
+    EditComment {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Issue ID
+        id: u64,
+
+        /// Comment ID
+        comment_id: u64,
+
+        /// New comment text
+        #[arg(short, long)]
+        body: String,
+    },
+
+    /// Delete a comment from an issue
+    DeleteComment {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Issue ID
+        id: u64,
+
+        /// Comment ID
+        comment_id: u64,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+
+    /// List the change log of an issue
+    Changes {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Issue ID
+        id: u64,
+
+        /// Number of results (capped at 100)
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+    },
+
+    /// Vote for an issue
+    Vote {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Issue ID
+        id: u64,
+    },
+
+    /// Remove your vote from an issue
+    Unvote {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Issue ID
+        id: u64,
+    },
+
+    /// Watch an issue
+    Watch {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Issue ID
+        id: u64,
+    },
+
+    /// Stop watching an issue
+    Unwatch {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Issue ID
+        id: u64,
+    },
+
+    /// List the components defined in the issue tracker
+    Components {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+    },
+
+    /// List the milestones defined in the issue tracker
+    Milestones {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+    },
+
+    /// List the versions defined in the issue tracker
+    Versions {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+    },
+
+    /// Manage files attached to an issue
+    Attachment {
+        #[command(subcommand)]
+        command: AttachmentCommands,
     },
 
     /// Close an issue
@@ -89,6 +309,47 @@ pub enum IssueCommands {
 
         /// Issue ID
         id: u64,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum AttachmentCommands {
+    /// List files attached to an issue
+    List {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Issue ID
+        id: u64,
+    },
+
+    /// Attach one or more files to an issue
+    Add {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Issue ID
+        id: u64,
+
+        /// Files to attach
+        #[arg(required = true)]
+        files: Vec<PathBuf>,
+    },
+
+    /// Delete an attachment from an issue
+    Delete {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Issue ID
+        id: u64,
+
+        /// Attachment path (the filename shown by `issue attachment list`)
+        path: String,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
     },
 }
 
@@ -173,22 +434,93 @@ struct IssueRow {
     priority: String,
 }
 
+#[derive(Tabled)]
+struct CommentRow {
+    #[tabled(rename = "ID")]
+    id: u64,
+    #[tabled(rename = "AUTHOR")]
+    author: String,
+    #[tabled(rename = "CREATED")]
+    created: String,
+    #[tabled(rename = "COMMENT")]
+    comment: String,
+}
+
+#[derive(Tabled)]
+struct ChangeRow {
+    #[tabled(rename = "ID")]
+    id: String,
+    #[tabled(rename = "USER")]
+    user: String,
+    #[tabled(rename = "DATE")]
+    date: String,
+    #[tabled(rename = "CHANGED")]
+    changed: String,
+}
+
+#[derive(Tabled)]
+struct MetaRow {
+    #[tabled(rename = "ID")]
+    id: String,
+    #[tabled(rename = "NAME")]
+    name: String,
+}
+
+#[derive(Tabled)]
+struct AttachmentRow {
+    #[tabled(rename = "NAME")]
+    name: String,
+    #[tabled(rename = "LINK")]
+    link: String,
+}
+
 impl IssueCommands {
     pub async fn run(self) -> Result<()> {
         match self {
-            IssueCommands::List { repo, state, limit } => {
+            IssueCommands::List {
+                repo,
+                state,
+                kind,
+                priority,
+                assignee,
+                reporter,
+                query,
+                sort,
+                page,
+                limit,
+            } => {
                 let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                let capped = capped_limit(limit);
+                if capped != limit && !super::output_json() {
+                    println!(
+                        "{} Limit capped at {} (the Bitbucket API maximum)",
+                        "ℹ".blue(),
+                        MAX_LIMIT
+                    );
+                }
+
                 let client = BitbucketClient::from_stored().await?;
 
+                let filters = IssueListFilters {
+                    state: state.map(Into::into),
+                    kind: kind.map(Into::into),
+                    priority: priority.map(Into::into),
+                    assignee: assignee.as_deref(),
+                    reporter: reporter.as_deref(),
+                    query: query.as_deref(),
+                    sort: sort.as_deref(),
+                    page,
+                    pagelen: Some(capped),
+                };
+
                 let issues = client
-                    .list_issues(
-                        &workspace,
-                        &repo_slug,
-                        state.map(|s| s.into()),
-                        None,
-                        Some(limit),
-                    )
+                    .list_issues_filtered(&workspace, &repo_slug, &filters)
                     .await?;
+
+                if super::output_json() {
+                    return super::print_json(&issues.values);
+                }
 
                 if issues.values.is_empty() {
                     println!("No issues found");
@@ -210,15 +542,29 @@ impl IssueCommands {
                 let table = Table::new(rows).to_string();
                 println!("{}", table);
 
+                if issues.next.is_some() {
+                    println!(
+                        "{} More issues available; use --page/--limit to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
                 Ok(())
             }
 
-            IssueCommands::View { repo, id, web } => {
+            IssueCommands::View {
+                repo,
+                id,
+                comments,
+                web,
+            } => {
                 let (workspace, repo_slug) = parse_repo(&repo)?;
                 let client = BitbucketClient::from_stored().await?;
                 let issue = client.get_issue(&workspace, &repo_slug, id).await?;
 
-                if web {
+                // In json mode, skip the browser and fall through to emit the
+                // issue JSON below.
+                if web && !super::output_json() {
                     if let Some(links) = &issue.links {
                         if let Some(html) = &links.html {
                             open::that(&html.href)?;
@@ -227,6 +573,19 @@ impl IssueCommands {
                         }
                     }
                     anyhow::bail!("Could not find issue URL");
+                }
+
+                if super::output_json() {
+                    if comments {
+                        let thread = client
+                            .list_issue_comments(&workspace, &repo_slug, id, Some(MAX_LIMIT))
+                            .await?;
+                        return super::print_json(&serde_json::json!({
+                            "issue": issue,
+                            "comments": thread.values,
+                        }));
+                    }
+                    return super::print_json(&issue);
                 }
 
                 println!(
@@ -288,6 +647,29 @@ impl IssueCommands {
                     }
                 }
 
+                if comments {
+                    let thread = client
+                        .list_issue_comments(&workspace, &repo_slug, id, Some(MAX_LIMIT))
+                        .await?;
+
+                    println!();
+                    if thread.values.is_empty() {
+                        println!("No comments");
+                    } else {
+                        println!("{}", format!("Comments ({})", thread.values.len()).bold());
+                        for comment in &thread.values {
+                            println!("{}", "─".repeat(60));
+                            print_comment(comment);
+                        }
+                        if thread.next.is_some() {
+                            println!(
+                                "{} More comments available; use 'issue comments' to page through them.",
+                                "ℹ".blue()
+                            );
+                        }
+                    }
+                }
+
                 Ok(())
             }
 
@@ -297,6 +679,10 @@ impl IssueCommands {
                 body,
                 kind,
                 priority,
+                assignee,
+                component,
+                milestone,
+                version,
             } => {
                 let (workspace, repo_slug) = parse_repo(&repo)?;
                 let client = BitbucketClient::from_stored().await?;
@@ -306,15 +692,19 @@ impl IssueCommands {
                     content: body.map(|b| IssueContentRequest { raw: b }),
                     kind: Some(kind.into()),
                     priority: Some(priority.into()),
-                    assignee: None,
-                    component: None,
-                    milestone: None,
-                    version: None,
+                    assignee: assignee.map(|account_id| UserAccountId { account_id }),
+                    component: component.map(|name| ComponentName { name }),
+                    milestone: milestone.map(|name| MilestoneName { name }),
+                    version: version.map(|name| VersionName { name }),
                 };
 
                 let issue = client
                     .create_issue(&workspace, &repo_slug, &request)
                     .await?;
+
+                if super::output_json() {
+                    return super::print_json(&issue);
+                }
 
                 println!("{} Created issue #{}", "✓".green(), issue.id);
 
@@ -327,24 +717,354 @@ impl IssueCommands {
                 Ok(())
             }
 
+            IssueCommands::Edit {
+                repo,
+                id,
+                title,
+                body,
+                kind,
+                priority,
+                assignee,
+                state,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                let update = IssueUpdate {
+                    title: title.as_deref(),
+                    content: body.as_deref(),
+                    kind: kind.map(Into::into),
+                    priority: priority.map(Into::into),
+                    assignee: assignee.as_deref(),
+                    state: state.map(Into::into),
+                };
+
+                if update.is_empty() {
+                    anyhow::bail!(
+                        "Nothing to edit: pass at least one of --title, --body, --kind, --priority, --assignee or --state"
+                    );
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                let issue = client
+                    .update_issue_full(&workspace, &repo_slug, id, &update)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&issue);
+                }
+
+                println!("{} Updated issue #{}", "✓".green(), issue.id);
+
+                Ok(())
+            }
+
+            IssueCommands::Delete { repo, id, yes } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                if !yes
+                    && !confirm_or_abort(format!(
+                        "Delete issue {} from {}?",
+                        format!("#{}", id).red(),
+                        repo
+                    ))?
+                {
+                    return Ok(());
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                client.delete_issue(&workspace, &repo_slug, id).await?;
+
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
+                println!("{} Deleted issue #{}", "✓".green(), id);
+
+                Ok(())
+            }
+
             IssueCommands::Comment { repo, id, body } => {
                 let (workspace, repo_slug) = parse_repo(&repo)?;
                 let client = BitbucketClient::from_stored().await?;
 
-                client
+                let comment = client
                     .add_issue_comment(&workspace, &repo_slug, id, &body)
                     .await?;
+
+                if super::output_json() {
+                    return super::print_json(&comment);
+                }
 
                 println!("{} Added comment to issue #{}", "✓".green(), id);
 
                 Ok(())
             }
 
+            IssueCommands::Comments { repo, id, limit } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                let capped = capped_limit(limit);
+                if capped != limit && !super::output_json() {
+                    println!(
+                        "{} Limit capped at {} (the Bitbucket API maximum)",
+                        "ℹ".blue(),
+                        MAX_LIMIT
+                    );
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                let comments = client
+                    .list_issue_comments(&workspace, &repo_slug, id, Some(capped))
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&comments.values);
+                }
+
+                if comments.values.is_empty() {
+                    println!("No comments found on issue #{}", id);
+                    return Ok(());
+                }
+
+                let rows: Vec<CommentRow> = comments
+                    .values
+                    .iter()
+                    .map(|comment| CommentRow {
+                        id: comment.id,
+                        author: comment.user.display_name.clone(),
+                        created: comment.created_on.format("%Y-%m-%d %H:%M").to_string(),
+                        comment: summarize_text(comment.content.raw.as_deref()),
+                    })
+                    .collect();
+
+                let table = Table::new(rows).to_string();
+                println!("{}", table);
+
+                if comments.next.is_some() {
+                    println!(
+                        "{} More comments available; use --limit to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
+                Ok(())
+            }
+
+            IssueCommands::EditComment {
+                repo,
+                id,
+                comment_id,
+                body,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let comment = client
+                    .update_issue_comment(&workspace, &repo_slug, id, comment_id, &body)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&comment);
+                }
+
+                println!(
+                    "{} Updated comment {} on issue #{}",
+                    "✓".green(),
+                    comment_id,
+                    id
+                );
+
+                Ok(())
+            }
+
+            IssueCommands::DeleteComment {
+                repo,
+                id,
+                comment_id,
+                yes,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                if !yes
+                    && !confirm_or_abort(format!(
+                        "Delete comment {} from issue #{} in {}?",
+                        comment_id.to_string().red(),
+                        id,
+                        repo
+                    ))?
+                {
+                    return Ok(());
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                client
+                    .delete_issue_comment(&workspace, &repo_slug, id, comment_id)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
+                println!(
+                    "{} Deleted comment {} from issue #{}",
+                    "✓".green(),
+                    comment_id,
+                    id
+                );
+
+                Ok(())
+            }
+
+            IssueCommands::Changes { repo, id, limit } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                let capped = capped_limit(limit);
+                if capped != limit && !super::output_json() {
+                    println!(
+                        "{} Limit capped at {} (the Bitbucket API maximum)",
+                        "ℹ".blue(),
+                        MAX_LIMIT
+                    );
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                let changes = client
+                    .list_issue_changes(&workspace, &repo_slug, id, Some(capped))
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&changes.values);
+                }
+
+                if changes.values.is_empty() {
+                    println!("No changes found for issue #{}", id);
+                    return Ok(());
+                }
+
+                let rows: Vec<ChangeRow> = changes.values.iter().map(change_row).collect();
+
+                let table = Table::new(rows).to_string();
+                println!("{}", table);
+
+                if changes.next.is_some() {
+                    println!(
+                        "{} More changes available; use --limit to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
+                Ok(())
+            }
+
+            IssueCommands::Vote { repo, id } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                client.vote_issue(&workspace, &repo_slug, id).await?;
+
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
+                println!("{} Voted for issue #{}", "✓".green(), id);
+
+                Ok(())
+            }
+
+            IssueCommands::Unvote { repo, id } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                client.unvote_issue(&workspace, &repo_slug, id).await?;
+
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
+                println!("{} Removed vote from issue #{}", "✓".green(), id);
+
+                Ok(())
+            }
+
+            IssueCommands::Watch { repo, id } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                client.watch_issue(&workspace, &repo_slug, id).await?;
+
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
+                println!("{} Watching issue #{}", "✓".green(), id);
+
+                Ok(())
+            }
+
+            IssueCommands::Unwatch { repo, id } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                client.unwatch_issue(&workspace, &repo_slug, id).await?;
+
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
+                println!("{} Stopped watching issue #{}", "✓".green(), id);
+
+                Ok(())
+            }
+
+            IssueCommands::Components { repo } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let items = client.list_issue_components(&workspace, &repo_slug).await?;
+
+                if super::output_json() {
+                    return super::print_json(&items);
+                }
+
+                print_meta_items(&items, "components");
+
+                Ok(())
+            }
+
+            IssueCommands::Milestones { repo } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let items = client.list_issue_milestones(&workspace, &repo_slug).await?;
+
+                if super::output_json() {
+                    return super::print_json(&items);
+                }
+
+                print_meta_items(&items, "milestones");
+
+                Ok(())
+            }
+
+            IssueCommands::Versions { repo } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let items = client.list_issue_versions(&workspace, &repo_slug).await?;
+
+                if super::output_json() {
+                    return super::print_json(&items);
+                }
+
+                print_meta_items(&items, "versions");
+
+                Ok(())
+            }
+
+            IssueCommands::Attachment { command } => command.run().await,
+
             IssueCommands::Close { repo, id } => {
                 let (workspace, repo_slug) = parse_repo(&repo)?;
                 let client = BitbucketClient::from_stored().await?;
 
-                client
+                let issue = client
                     .update_issue(
                         &workspace,
                         &repo_slug,
@@ -355,6 +1075,10 @@ impl IssueCommands {
                     )
                     .await?;
 
+                if super::output_json() {
+                    return super::print_json(&issue);
+                }
+
                 println!("{} Closed issue #{}", "✓".green(), id);
 
                 Ok(())
@@ -364,7 +1088,7 @@ impl IssueCommands {
                 let (workspace, repo_slug) = parse_repo(&repo)?;
                 let client = BitbucketClient::from_stored().await?;
 
-                client
+                let issue = client
                     .update_issue(
                         &workspace,
                         &repo_slug,
@@ -375,7 +1099,124 @@ impl IssueCommands {
                     )
                     .await?;
 
+                if super::output_json() {
+                    return super::print_json(&issue);
+                }
+
                 println!("{} Reopened issue #{}", "✓".green(), id);
+
+                Ok(())
+            }
+        }
+    }
+}
+
+impl AttachmentCommands {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            AttachmentCommands::List { repo, id } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let attachments = client
+                    .list_issue_attachments(&workspace, &repo_slug, id)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&attachments);
+                }
+
+                if attachments.is_empty() {
+                    println!("No attachments found on issue #{}", id);
+                    return Ok(());
+                }
+
+                let rows: Vec<AttachmentRow> = attachments
+                    .iter()
+                    .map(|attachment| AttachmentRow {
+                        name: attachment.name.clone().unwrap_or_else(|| "-".to_string()),
+                        link: attachment_link(attachment),
+                    })
+                    .collect();
+
+                let table = Table::new(rows).to_string();
+                println!("{}", table);
+
+                Ok(())
+            }
+
+            AttachmentCommands::Add { repo, id, files } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                // Resolve each path to (upload-name, path) up front so a bad
+                // path fails before we open a network connection.
+                let uploads: Vec<(String, PathBuf)> = files
+                    .iter()
+                    .map(|p| Ok((attachment_name_for(p)?, p.clone())))
+                    .collect::<Result<_>>()?;
+
+                // Bitbucket keys attachments by filename, so two inputs with
+                // the same basename would silently overwrite each other
+                // server-side.
+                let mut seen = HashSet::new();
+                for (name, _) in &uploads {
+                    if !seen.insert(name.as_str()) {
+                        anyhow::bail!(
+                            "Duplicate attachment name '{}': multiple input files share this filename; Bitbucket stores attachments by filename, so one would overwrite the other",
+                            name
+                        );
+                    }
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                client
+                    .upload_issue_attachments(&workspace, &repo_slug, id, &uploads)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
+                for (name, _) in &uploads {
+                    println!("{} Attached {} to issue #{}", "✓".green(), name.cyan(), id);
+                }
+
+                Ok(())
+            }
+
+            AttachmentCommands::Delete {
+                repo,
+                id,
+                path,
+                yes,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                if !yes
+                    && !confirm_or_abort(format!(
+                        "Delete attachment {} from issue #{} in {}?",
+                        path.red(),
+                        id,
+                        repo
+                    ))?
+                {
+                    return Ok(());
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                client
+                    .delete_issue_attachment(&workspace, &repo_slug, id, &path)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
+                println!(
+                    "{} Deleted attachment {} from issue #{}",
+                    "✓".green(),
+                    path,
+                    id
+                );
 
                 Ok(())
             }
@@ -403,5 +1244,239 @@ fn format_priority(priority: &IssuePriority) -> String {
         IssuePriority::Major => "major".yellow().to_string(),
         IssuePriority::Critical => "critical".red().to_string(),
         IssuePriority::Blocker => "blocker".red().bold().to_string(),
+    }
+}
+
+/// Print a single comment in thread style: header line, then the raw body.
+fn print_comment(comment: &IssueComment) {
+    println!(
+        "{} {} {}",
+        format!("#{}", comment.id).dimmed(),
+        comment.user.display_name.bold(),
+        comment
+            .created_on
+            .format("%Y-%m-%d %H:%M")
+            .to_string()
+            .dimmed()
+    );
+    if let Some(raw) = &comment.content.raw {
+        if !raw.is_empty() {
+            println!("{}", raw);
+        }
+    }
+}
+
+/// Flatten a possibly multi-line text into a single-line table cell,
+/// truncated to 60 characters. Empty or missing text renders as "-".
+fn summarize_text(raw: Option<&str>) -> String {
+    let flattened = raw
+        .unwrap_or("")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    if flattened.is_empty() {
+        return "-".to_string();
+    }
+
+    flattened.chars().take(60).collect()
+}
+
+/// Build a table row for one issue change-log entry: who, when, and the
+/// names of the fields that changed.
+fn change_row(change: &IssueChange) -> ChangeRow {
+    ChangeRow {
+        id: change
+            .id
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "-".to_string()),
+        user: change
+            .user
+            .as_ref()
+            .map(|u| u.display_name.clone())
+            .unwrap_or_else(|| "-".to_string()),
+        date: change
+            .created_on
+            .map(|d| d.format("%Y-%m-%d %H:%M").to_string())
+            .unwrap_or_else(|| "-".to_string()),
+        changed: changed_keys(change),
+    }
+}
+
+/// The comma-separated names of the fields touched by a change-log entry.
+fn changed_keys(change: &IssueChange) -> String {
+    let keys = change
+        .changes
+        .as_ref()
+        .and_then(|v| v.as_object())
+        .map(|obj| obj.keys().cloned().collect::<Vec<_>>().join(", "))
+        .unwrap_or_default();
+
+    if keys.is_empty() {
+        "-".to_string()
+    } else {
+        keys
+    }
+}
+
+/// Print components/milestones/versions as an id + name table.
+fn print_meta_items(items: &[IssueMetaItem], noun: &str) {
+    if items.is_empty() {
+        println!("No {} found", noun);
+        return;
+    }
+
+    let rows: Vec<MetaRow> = items
+        .iter()
+        .map(|item| MetaRow {
+            id: item
+                .id
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+            name: item.name.clone().unwrap_or_else(|| "-".to_string()),
+        })
+        .collect();
+
+    println!("{}", Table::new(rows));
+}
+
+/// Extract the self link of an attachment. The API serves `links.self.href`
+/// as either a string or an array of strings, so both shapes are handled.
+fn attachment_link(attachment: &IssueAttachment) -> String {
+    match attachment
+        .links
+        .as_ref()
+        .and_then(|links| links.pointer("/self/href"))
+    {
+        Some(serde_json::Value::String(s)) => s.clone(),
+        Some(serde_json::Value::Array(hrefs)) => hrefs
+            .iter()
+            .filter_map(|v| v.as_str())
+            .next()
+            .map(str::to_string)
+            .unwrap_or_else(|| "-".to_string()),
+        _ => "-".to_string(),
+    }
+}
+
+/// Extract the file name (final path component) from a path, for use as the
+/// uploaded attachment name.
+fn attachment_name_for(path: &Path) -> Result<String> {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map(|s| s.to_string())
+        .with_context(|| format!("Could not determine a file name for '{}'", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn summarize_text_flattens_newlines_and_truncates() {
+        assert_eq!(summarize_text(Some("a\nb\tc")), "a b c");
+        assert_eq!(summarize_text(None), "-");
+        assert_eq!(summarize_text(Some("   ")), "-");
+        let long = "x".repeat(80);
+        assert_eq!(summarize_text(Some(&long)).chars().count(), 60);
+    }
+
+    #[test]
+    fn attachment_link_handles_string_and_array_hrefs() {
+        let string_href = IssueAttachment {
+            name: Some("a.png".to_string()),
+            links: Some(serde_json::json!({"self": {"href": "https://x/a.png"}})),
+        };
+        assert_eq!(attachment_link(&string_href), "https://x/a.png");
+
+        let array_href = IssueAttachment {
+            name: Some("b.png".to_string()),
+            links: Some(
+                serde_json::json!({"self": {"href": ["https://x/b.png", "https://y/b.png"]}}),
+            ),
+        };
+        assert_eq!(attachment_link(&array_href), "https://x/b.png");
+
+        let missing = IssueAttachment {
+            name: None,
+            links: None,
+        };
+        assert_eq!(attachment_link(&missing), "-");
+    }
+
+    #[test]
+    fn changed_keys_joins_field_names_of_a_change_entry() {
+        let change = IssueChange {
+            id: Some(1),
+            user: None,
+            message: None,
+            created_on: None,
+            changes: Some(serde_json::json!({
+                "state": {"old": "new", "new": "open"},
+                "assignee": {"old": "", "new": "someone"},
+            })),
+        };
+        assert_eq!(changed_keys(&change), "assignee, state");
+
+        let empty = IssueChange {
+            id: None,
+            user: None,
+            message: None,
+            created_on: None,
+            changes: None,
+        };
+        assert_eq!(changed_keys(&empty), "-");
+    }
+
+    #[test]
+    fn attachment_name_for_extracts_basename_and_errors_without_one() {
+        assert_eq!(
+            attachment_name_for(Path::new("/some/dir/shot.png")).unwrap(),
+            "shot.png"
+        );
+        assert_eq!(
+            attachment_name_for(Path::new("shot.png")).unwrap(),
+            "shot.png"
+        );
+        // A path ending in ".." has no final file-name component.
+        assert!(attachment_name_for(Path::new("..")).is_err());
+    }
+
+    #[test]
+    fn change_row_renders_populated_and_empty_changes() {
+        let user = crate::models::User {
+            uuid: "u-1".to_string(),
+            username: None,
+            display_name: "Alice".to_string(),
+            account_id: None,
+            user_type: "user".to_string(),
+            links: None,
+        };
+        let created: chrono::DateTime<chrono::Utc> = "2024-01-15T10:30:00Z".parse().unwrap();
+        let populated = IssueChange {
+            id: Some(7),
+            user: Some(user),
+            message: None,
+            created_on: Some(created),
+            changes: Some(serde_json::json!({"state": {"old": "new", "new": "open"}})),
+        };
+        let row = change_row(&populated);
+        assert_eq!(row.id, "7");
+        assert_eq!(row.user, "Alice");
+        assert_eq!(row.date, "2024-01-15 10:30");
+        assert_eq!(row.changed, "state");
+
+        let empty = IssueChange {
+            id: None,
+            user: None,
+            message: None,
+            created_on: None,
+            changes: None,
+        };
+        let row = change_row(&empty);
+        assert_eq!(row.id, "-");
+        assert_eq!(row.user, "-");
+        assert_eq!(row.date, "-");
+        assert_eq!(row.changed, "-");
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,8 +1,20 @@
 pub mod auth;
+pub mod branch;
+pub mod branch_restriction;
+pub mod branching_model;
+pub mod commit;
+pub mod deploy;
+pub mod file;
 pub mod issue;
+pub mod pagination;
+pub mod permission;
 pub mod pipeline;
 pub mod pr;
 pub mod repo;
+pub mod reviewer;
+pub mod tag;
+pub mod user;
+pub mod webhook;
 pub mod workspace;
 
 use std::sync::OnceLock;
@@ -22,6 +34,19 @@ pub struct Cli {
     /// Workspace to use when omitted from arguments (overrides config default)
     #[arg(long, global = true)]
     pub workspace: Option<String>,
+
+    /// Output format for command results
+    #[arg(long, global = true, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
+}
+
+/// How command results are rendered.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, clap::ValueEnum)]
+pub enum OutputFormat {
+    /// Human-readable tables and text
+    Table,
+    /// Raw JSON for scripting
+    Json,
 }
 
 #[derive(Subcommand)]
@@ -62,8 +87,35 @@ pub enum Commands {
         command: workspace::WorkspaceCommands,
     },
 
+    /// Inspect Bitbucket user accounts
+    User {
+        #[command(subcommand)]
+        command: user::UserCommands,
+    },
+
     /// Launch interactive TUI
     Tui,
+}
+
+static OUTPUT_FORMAT: OnceLock<OutputFormat> = OnceLock::new();
+
+/// Record the global `--output` choice for this process.
+///
+/// `main` must call this once before dispatching a command; later calls are
+/// no-ops (set-once cell).
+pub fn set_output_format(format: OutputFormat) {
+    let _ = OUTPUT_FORMAT.set(format);
+}
+
+/// True when `--output json` was passed; handlers should emit raw JSON.
+pub fn output_json() -> bool {
+    OUTPUT_FORMAT.get().copied() == Some(OutputFormat::Json)
+}
+
+/// Serialize a value as pretty JSON to stdout.
+pub(crate) fn print_json<T: serde::Serialize>(value: &T) -> anyhow::Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
 }
 
 static WORKSPACE_OVERRIDE: OnceLock<Option<String>> = OnceLock::new();
@@ -108,6 +160,23 @@ fn resolve_workspace_with(
                 "No workspace specified. Pass a workspace argument, use --workspace, or set a default workspace in the config."
             )
         })
+}
+
+/// Ask the user to confirm a destructive action; on decline, print "Aborted"
+/// and return Ok(false).
+pub(crate) fn confirm_or_abort(prompt: String) -> anyhow::Result<bool> {
+    use dialoguer::Confirm;
+    let confirmed = Confirm::new()
+        .with_prompt(prompt)
+        .default(false)
+        .interact()?;
+
+    if !confirmed {
+        // stderr so an aborted run never corrupts `--output json` on stdout
+        eprintln!("Aborted");
+    }
+
+    Ok(confirmed)
 }
 
 /// Parse `workspace/repo-slug`, or a bare `repo-slug` resolved against

--- a/src/cli/pagination.rs
+++ b/src/cli/pagination.rs
@@ -1,0 +1,76 @@
+//! Shared pagination and formatting helpers for CLI list commands.
+
+use colored::Colorize;
+
+/// The maximum page size the Bitbucket API accepts.
+pub(crate) const MAX_LIMIT: u32 = 100;
+
+/// Cap a requested limit at [`MAX_LIMIT`], returning the effective value and
+/// whether it was reduced.
+pub(crate) fn cap_limit(limit: u32) -> (u32, bool) {
+    if limit > MAX_LIMIT {
+        (MAX_LIMIT, true)
+    } else {
+        (limit, false)
+    }
+}
+
+/// Cap `--limit` at [`MAX_LIMIT`], printing a notice (in table mode only) when
+/// the requested value is reduced. This is the single limit policy for every
+/// paginated command.
+pub(crate) fn effective_limit(limit: u32) -> u32 {
+    let (capped, was_capped) = cap_limit(limit);
+    if was_capped && !super::output_json() {
+        println!(
+            "{} --limit capped at {} (the Bitbucket API maximum)",
+            "ℹ".blue(),
+            MAX_LIMIT
+        );
+    }
+    capped
+}
+
+/// Format a byte count into a short human-readable string (decimal KB/MB/…).
+pub(crate) fn format_size(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    let mut size = bytes as f64;
+    let mut unit = 0;
+    while size >= 1024.0 && unit < UNITS.len() - 1 {
+        size /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{} {}", bytes, UNITS[unit])
+    } else {
+        format!("{:.1} {}", size, UNITS[unit])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MAX_LIMIT, cap_limit, format_size};
+
+    #[test]
+    fn cap_limit_passes_through_at_or_below_max() {
+        assert_eq!(cap_limit(25), (25, false));
+        assert_eq!(cap_limit(MAX_LIMIT), (MAX_LIMIT, false));
+    }
+
+    #[test]
+    fn cap_limit_reduces_above_max() {
+        assert_eq!(cap_limit(101), (MAX_LIMIT, true));
+        assert_eq!(cap_limit(1000), (MAX_LIMIT, true));
+    }
+
+    #[test]
+    fn format_size_uses_bytes_below_1k() {
+        assert_eq!(format_size(0), "0 B");
+        assert_eq!(format_size(1023), "1023 B");
+    }
+
+    #[test]
+    fn format_size_scales_to_larger_units() {
+        assert_eq!(format_size(1024), "1.0 KB");
+        assert_eq!(format_size(5 * 1024 * 1024 * 1024), "5.0 GB");
+    }
+}

--- a/src/cli/permission.rs
+++ b/src/cli/permission.rs
@@ -1,0 +1,316 @@
+use anyhow::Result;
+use clap::Subcommand;
+use colored::Colorize;
+use tabled::{Table, Tabled};
+
+use super::{confirm_or_abort, output_json, parse_repo, print_json};
+use crate::api::BitbucketClient;
+
+#[derive(Subcommand)]
+pub enum PermissionCommands {
+    /// List users with explicit permissions on a repository
+    ListUsers {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Number of results per page (max 100)
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+    },
+
+    /// List groups with explicit permissions on a repository
+    ListGroups {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Number of results per page (max 100)
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+    },
+
+    /// Grant or update a user's permission
+    GrantUser {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Account ID or brace-wrapped UUID of the user
+        user: String,
+
+        /// Permission level: read, write, or admin
+        #[arg(short, long)]
+        permission: String,
+    },
+
+    /// Revoke a user's explicit permission
+    RevokeUser {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Account ID or brace-wrapped UUID of the user
+        user: String,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+
+    /// Grant or update a group's permission
+    GrantGroup {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Slug of the workspace group
+        group: String,
+
+        /// Permission level: read, write, or admin
+        #[arg(short, long)]
+        permission: String,
+    },
+
+    /// Revoke a group's explicit permission
+    RevokeGroup {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Slug of the workspace group
+        group: String,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+}
+
+#[derive(Tabled)]
+struct UserPermissionRow {
+    #[tabled(rename = "NAME")]
+    name: String,
+    #[tabled(rename = "UUID")]
+    uuid: String,
+    #[tabled(rename = "PERMISSION")]
+    permission: String,
+}
+
+#[derive(Tabled)]
+struct GroupPermissionRow {
+    #[tabled(rename = "NAME")]
+    name: String,
+    #[tabled(rename = "SLUG")]
+    slug: String,
+    #[tabled(rename = "PERMISSION")]
+    permission: String,
+}
+
+impl PermissionCommands {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            PermissionCommands::ListUsers { repo, limit } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let permissions = client
+                    .list_user_permissions(&workspace, &repo_slug, Some(limit.clamp(1, 100)))
+                    .await?;
+
+                if output_json() {
+                    return print_json(&permissions.values);
+                }
+
+                if permissions.values.is_empty() {
+                    println!("No explicit user permissions found in {}", repo);
+                    return Ok(());
+                }
+
+                let rows: Vec<UserPermissionRow> = permissions
+                    .values
+                    .iter()
+                    .map(|p| UserPermissionRow {
+                        name: p
+                            .user
+                            .as_ref()
+                            .map(|u| u.display_name.clone())
+                            .unwrap_or_default(),
+                        uuid: p.user.as_ref().map(|u| u.uuid.clone()).unwrap_or_default(),
+                        permission: p.permission.clone(),
+                    })
+                    .collect();
+
+                println!("{}", Table::new(rows));
+
+                if permissions.next.is_some() {
+                    println!(
+                        "\n{} More user permissions available. Use --limit to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
+                Ok(())
+            }
+
+            PermissionCommands::ListGroups { repo, limit } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let permissions = client
+                    .list_group_permissions(&workspace, &repo_slug, Some(limit.clamp(1, 100)))
+                    .await?;
+
+                if output_json() {
+                    return print_json(&permissions.values);
+                }
+
+                if permissions.values.is_empty() {
+                    println!("No explicit group permissions found in {}", repo);
+                    return Ok(());
+                }
+
+                let rows: Vec<GroupPermissionRow> = permissions
+                    .values
+                    .iter()
+                    .map(|p| GroupPermissionRow {
+                        name: p
+                            .group
+                            .as_ref()
+                            .and_then(|g| g.name.clone())
+                            .unwrap_or_default(),
+                        slug: p
+                            .group
+                            .as_ref()
+                            .and_then(|g| g.slug.clone())
+                            .unwrap_or_default(),
+                        permission: p.permission.clone(),
+                    })
+                    .collect();
+
+                println!("{}", Table::new(rows));
+
+                if permissions.next.is_some() {
+                    println!(
+                        "\n{} More group permissions available. Use --limit to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
+                Ok(())
+            }
+
+            PermissionCommands::GrantUser {
+                repo,
+                user,
+                permission,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let granted = client
+                    .grant_user_permission(&workspace, &repo_slug, &user, &permission)
+                    .await?;
+
+                if output_json() {
+                    return print_json(&granted);
+                }
+
+                let label = granted
+                    .user
+                    .as_ref()
+                    .map(|u| u.display_name.clone())
+                    .unwrap_or(user);
+
+                println!(
+                    "{} Granted {} permission to {} on {}",
+                    "✓".green(),
+                    granted.permission.cyan(),
+                    label.cyan(),
+                    repo
+                );
+
+                Ok(())
+            }
+
+            PermissionCommands::RevokeUser { repo, user, yes } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                if !yes
+                    && !confirm_or_abort(format!(
+                        "Revoke {}'s explicit permission on {}?",
+                        user.red(),
+                        repo
+                    ))?
+                {
+                    return Ok(());
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                client
+                    .revoke_user_permission(&workspace, &repo_slug, &user)
+                    .await?;
+
+                if output_json() {
+                    return print_json(&serde_json::json!({ "ok": true }));
+                }
+
+                println!("{} Revoked permission for {}", "✓".green(), user);
+
+                Ok(())
+            }
+
+            PermissionCommands::GrantGroup {
+                repo,
+                group,
+                permission,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let granted = client
+                    .grant_group_permission(&workspace, &repo_slug, &group, &permission)
+                    .await?;
+
+                if output_json() {
+                    return print_json(&granted);
+                }
+
+                let label = granted
+                    .group
+                    .as_ref()
+                    .and_then(|g| g.name.clone().or_else(|| g.slug.clone()))
+                    .unwrap_or(group);
+
+                println!(
+                    "{} Granted {} permission to group {} on {}",
+                    "✓".green(),
+                    granted.permission.cyan(),
+                    label.cyan(),
+                    repo
+                );
+
+                Ok(())
+            }
+
+            PermissionCommands::RevokeGroup { repo, group, yes } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                if !yes
+                    && !confirm_or_abort(format!(
+                        "Revoke group {}'s explicit permission on {}?",
+                        group.red(),
+                        repo
+                    ))?
+                {
+                    return Ok(());
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                client
+                    .revoke_group_permission(&workspace, &repo_slug, &group)
+                    .await?;
+
+                if output_json() {
+                    return print_json(&serde_json::json!({ "ok": true }));
+                }
+
+                println!("{} Revoked permission for group {}", "✓".green(), group);
+
+                Ok(())
+            }
+        }
+    }
+}

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -1,12 +1,16 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Subcommand;
-use colored::Colorize;
+use colored::{ColoredString, Colorize};
 use indicatif::{ProgressBar, ProgressStyle};
 use tabled::{Table, Tabled};
 
-use super::parse_repo;
+use super::{confirm_or_abort, parse_repo, resolve_workspace};
 use crate::api::BitbucketClient;
-use crate::models::{PipelineResultName, PipelineStateName, TriggerPipelineRequest};
+use crate::cli::pagination::effective_limit;
+use crate::models::{
+    Pipeline, PipelineResultName, PipelineStateName, PipelineStep, PipelineVariable,
+    PipelineVariableInput, TriggerPipelineRequest, TriggerPipelineSelector,
+};
 
 #[derive(Subcommand)]
 pub enum PipelineCommands {
@@ -15,9 +19,25 @@ pub enum PipelineCommands {
         /// Repository in format workspace/repo-slug
         repo: String,
 
-        /// Number of results
+        /// Number of results (capped at 100)
         #[arg(short, long, default_value = "25")]
         limit: u32,
+
+        /// Filter by status (PENDING, IN_PROGRESS, COMPLETED, ...)
+        #[arg(long)]
+        status: Option<String>,
+
+        /// Filter by target branch name
+        #[arg(long)]
+        target_branch: Option<String>,
+
+        /// Sort order (default: -created_on, most recent first)
+        #[arg(long)]
+        sort: Option<String>,
+
+        /// Page number to fetch
+        #[arg(long)]
+        page: Option<u32>,
     },
 
     /// View pipeline details
@@ -32,6 +52,14 @@ pub enum PipelineCommands {
         /// Show step logs
         #[arg(short, long)]
         logs: bool,
+
+        /// Show only one step: a 1-based index or a step UUID prefix
+        #[arg(long)]
+        step: Option<String>,
+
+        /// Print complete step logs instead of the first 50 lines (implies --logs)
+        #[arg(long)]
+        full_logs: bool,
     },
 
     /// Trigger a new pipeline
@@ -43,9 +71,21 @@ pub enum PipelineCommands {
         #[arg(short, long, default_value = "main")]
         branch: String,
 
+        /// Commit hash to run the pipeline on (takes precedence over --branch)
+        #[arg(long)]
+        commit: Option<String>,
+
         /// Custom pipeline name (from bitbucket-pipelines.yml)
         #[arg(short, long)]
         pipeline: Option<String>,
+
+        /// Pipeline variable as KEY=VALUE (repeatable)
+        #[arg(long, value_name = "KEY=VALUE")]
+        var: Vec<String>,
+
+        /// Secured pipeline variable as KEY=VALUE, masked in logs (repeatable)
+        #[arg(long, value_name = "KEY=VALUE")]
+        secured_var: Vec<String>,
 
         /// Wait for pipeline to complete
         #[arg(short, long)]
@@ -58,8 +98,198 @@ pub enum PipelineCommands {
         repo: String,
 
         /// Pipeline build number
+        #[arg(short, long, required_unless_present = "uuid")]
+        build: Option<u64>,
+
+        /// Pipeline UUID (skips the build-number lookup)
+        #[arg(long, conflicts_with = "build")]
+        uuid: Option<String>,
+    },
+
+    /// Re-run a pipeline by triggering an equivalent one
+    Rerun {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Build number of the pipeline to re-run
         #[arg(short, long)]
         build: u64,
+    },
+
+    /// View or update the repository pipelines configuration
+    Config {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Enable pipelines for the repository
+        #[arg(long, conflicts_with = "disable")]
+        enable: bool,
+
+        /// Disable pipelines for the repository
+        #[arg(long)]
+        disable: bool,
+
+        /// Set the next pipeline build number
+        #[arg(long)]
+        next_build_number: Option<u64>,
+    },
+
+    /// Manage repository pipeline variables
+    Variable {
+        #[command(subcommand)]
+        command: VariableCommands,
+    },
+
+    /// Manage workspace-level pipeline variables
+    WorkspaceVariable {
+        #[command(subcommand)]
+        command: WorkspaceVariableCommands,
+    },
+
+    /// Manage pipeline schedules
+    Schedule {
+        #[command(subcommand)]
+        command: ScheduleCommands,
+    },
+
+    /// Manage pipeline dependency caches
+    Cache {
+        #[command(subcommand)]
+        command: CacheCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum VariableCommands {
+    /// List pipeline variables
+    List {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+    },
+
+    /// Create or update a pipeline variable
+    Set {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Variable name
+        key: String,
+
+        /// Variable value
+        value: String,
+
+        /// Mask the value in logs and the UI
+        #[arg(long)]
+        secured: bool,
+    },
+
+    /// Delete a pipeline variable by key
+    Delete {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Variable name
+        key: String,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum WorkspaceVariableCommands {
+    /// List workspace pipeline variables
+    List {
+        /// Workspace (defaults to --workspace or the configured default)
+        workspace: Option<String>,
+    },
+
+    /// Create or update a workspace pipeline variable
+    Set {
+        /// Variable name
+        key: String,
+
+        /// Variable value
+        value: String,
+
+        /// Workspace (defaults to --workspace or the configured default)
+        workspace: Option<String>,
+
+        /// Mask the value in logs and the UI
+        #[arg(long)]
+        secured: bool,
+    },
+
+    /// Delete a workspace pipeline variable by key
+    Delete {
+        /// Variable name
+        key: String,
+
+        /// Workspace (defaults to --workspace or the configured default)
+        workspace: Option<String>,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum ScheduleCommands {
+    /// List pipeline schedules
+    List {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+    },
+
+    /// Create a pipeline schedule
+    Create {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Branch to run the scheduled pipeline on
+        #[arg(long)]
+        branch: String,
+
+        /// Cron pattern (e.g. "0 0 12 * * ? *")
+        #[arg(long)]
+        cron: String,
+    },
+
+    /// Delete a pipeline schedule by UUID
+    Delete {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Schedule UUID (with or without braces)
+        uuid: String,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum CacheCommands {
+    /// List pipeline dependency caches
+    List {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+    },
+
+    /// Delete pipeline dependency caches by name
+    Delete {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Cache name (as shown by 'cache list')
+        name: String,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
     },
 }
 
@@ -77,16 +307,74 @@ struct PipelineRow {
     duration: String,
 }
 
+#[derive(Tabled)]
+struct VariableRow {
+    #[tabled(rename = "KEY")]
+    key: String,
+    #[tabled(rename = "VALUE")]
+    value: String,
+    #[tabled(rename = "SECURED")]
+    secured: String,
+    #[tabled(rename = "UUID")]
+    uuid: String,
+}
+
+#[derive(Tabled)]
+struct ScheduleRow {
+    #[tabled(rename = "ENABLED")]
+    enabled: String,
+    #[tabled(rename = "CRON")]
+    cron: String,
+    #[tabled(rename = "BRANCH")]
+    branch: String,
+    #[tabled(rename = "UUID")]
+    uuid: String,
+}
+
+#[derive(Tabled)]
+struct CacheRow {
+    #[tabled(rename = "NAME")]
+    name: String,
+    #[tabled(rename = "PATH")]
+    path: String,
+    #[tabled(rename = "SIZE")]
+    size: String,
+    #[tabled(rename = "UUID")]
+    uuid: String,
+}
+
 impl PipelineCommands {
     pub async fn run(self) -> Result<()> {
         match self {
-            PipelineCommands::List { repo, limit } => {
+            PipelineCommands::List {
+                repo,
+                limit,
+                status,
+                target_branch,
+                sort,
+                page,
+            } => {
                 let (workspace, repo_slug) = parse_repo(&repo)?;
                 let client = BitbucketClient::from_stored().await?;
+                let limit = effective_limit(limit);
 
                 let pipelines = client
-                    .list_pipelines(&workspace, &repo_slug, None, Some(limit))
+                    .list_pipelines_filtered(
+                        &workspace,
+                        &repo_slug,
+                        crate::api::pipelines::PipelineListFilters {
+                            page,
+                            pagelen: Some(limit),
+                            status: status.as_deref(),
+                            target_branch: target_branch.as_deref(),
+                            sort: sort.as_deref(),
+                        },
+                    )
                     .await?;
+
+                if super::output_json() {
+                    return super::print_json(&pipelines.values);
+                }
 
                 if pipelines.values.is_empty() {
                     println!("No pipelines found");
@@ -124,13 +412,52 @@ impl PipelineCommands {
                 Ok(())
             }
 
-            PipelineCommands::View { repo, build, logs } => {
+            PipelineCommands::View {
+                repo,
+                build,
+                logs,
+                step,
+                full_logs,
+            } => {
                 let (workspace, repo_slug) = parse_repo(&repo)?;
                 let client = BitbucketClient::from_stored().await?;
+                let show_logs = logs || full_logs;
 
                 let pipeline = client
                     .get_pipeline_by_build_number(&workspace, &repo_slug, build)
                     .await?;
+
+                if super::output_json() && !show_logs {
+                    let steps = client
+                        .list_pipeline_steps(&workspace, &repo_slug, &pipeline.uuid)
+                        .await?;
+
+                    let steps = match &step {
+                        Some(selector) => {
+                            let (index, by_uuid) = select_step(&steps.values, selector)?;
+                            let chosen = &steps.values[index];
+                            let detail = if by_uuid {
+                                client
+                                    .get_pipeline_step(
+                                        &workspace,
+                                        &repo_slug,
+                                        &pipeline.uuid,
+                                        &chosen.uuid,
+                                    )
+                                    .await?
+                            } else {
+                                chosen.clone()
+                            };
+                            vec![detail]
+                        }
+                        None => steps.values,
+                    };
+
+                    return super::print_json(&serde_json::json!({
+                        "pipeline": pipeline,
+                        "steps": steps,
+                    }));
+                }
 
                 println!(
                     "{} Pipeline #{} - {}",
@@ -169,67 +496,72 @@ impl PipelineCommands {
                     println!("{} {}", "Duration:".dimmed(), format_duration(seconds));
                 }
 
-                // Show pipeline steps
                 let steps = client
                     .list_pipeline_steps(&workspace, &repo_slug, &pipeline.uuid)
                     .await?;
+
+                if let Some(selector) = step {
+                    let (index, by_uuid) = select_step(&steps.values, &selector)?;
+                    let chosen = &steps.values[index];
+
+                    // A UUID selection points at one concrete step, so use the
+                    // dedicated step endpoint for the freshest detail.
+                    let detail = if by_uuid {
+                        client
+                            .get_pipeline_step(&workspace, &repo_slug, &pipeline.uuid, &chosen.uuid)
+                            .await?
+                    } else {
+                        chosen.clone()
+                    };
+
+                    print_step_detail(&detail);
+
+                    if show_logs {
+                        // A single step was explicitly requested, so a failed
+                        // log fetch is worth surfacing rather than swallowing.
+                        if let Err(e) = print_step_log(
+                            &client,
+                            &workspace,
+                            &repo_slug,
+                            &pipeline.uuid,
+                            &detail.uuid,
+                            full_logs,
+                        )
+                        .await
+                        {
+                            eprintln!(
+                                "{} could not fetch log for step {}: {}",
+                                "⚠".yellow(),
+                                detail.name.as_deref().unwrap_or(&detail.uuid),
+                                e
+                            );
+                        }
+                    }
+
+                    return Ok(());
+                }
 
                 if !steps.values.is_empty() {
                     println!();
                     println!("{}", "Steps:".bold());
 
                     for step in &steps.values {
-                        let status = step
-                            .state
-                            .as_ref()
-                            .map(|s| s.name.as_str())
-                            .unwrap_or("unknown");
-
-                        let status_icon = match status {
-                            "COMPLETED" => {
-                                let result = step
-                                    .state
-                                    .as_ref()
-                                    .and_then(|s| s.result.as_ref())
-                                    .map(|r| r.name.as_str())
-                                    .unwrap_or("");
-                                match result {
-                                    "SUCCESSFUL" => "✓".green(),
-                                    "FAILED" => "✗".red(),
-                                    _ => "○".normal(),
-                                }
-                            }
-                            "IN_PROGRESS" => "◉".blue(),
-                            "PENDING" => "○".dimmed(),
-                            _ => "○".normal(),
-                        };
-
                         let name = step.name.as_deref().unwrap_or("Step");
-                        println!("  {} {}", status_icon, name);
+                        println!("  {} {}", step_status_icon(step), name);
 
-                        if logs {
-                            // Fetch and display step log
-                            match client
-                                .get_step_log(&workspace, &repo_slug, &pipeline.uuid, &step.uuid)
-                                .await
-                            {
-                                Ok(log) => {
-                                    if !log.is_empty() {
-                                        println!();
-                                        let (shown, truncated) = take_log_lines(&log, 50);
-                                        for line in shown {
-                                            println!("    {}", line.dimmed());
-                                        }
-                                        if truncated {
-                                            println!("    {} ... (truncated)", "".dimmed());
-                                        }
-                                        println!();
-                                    }
-                                }
-                                Err(_) => {
-                                    // Log might not be available yet
-                                }
-                            }
+                        if show_logs {
+                            // Iterating over every step: logs for pending or
+                            // in-progress steps may not exist yet, so ignore
+                            // fetch errors here.
+                            let _ = print_step_log(
+                                &client,
+                                &workspace,
+                                &repo_slug,
+                                &pipeline.uuid,
+                                &step.uuid,
+                                full_logs,
+                            )
+                            .await;
                         }
                     }
                 }
@@ -240,99 +572,102 @@ impl PipelineCommands {
             PipelineCommands::Trigger {
                 repo,
                 branch,
+                commit,
                 pipeline,
+                var,
+                secured_var,
                 wait,
             } => {
                 let (workspace, repo_slug) = parse_repo(&repo)?;
                 let client = BitbucketClient::from_stored().await?;
 
-                let request = if let Some(pipeline_name) = pipeline {
-                    TriggerPipelineRequest::for_branch_with_pipeline(&branch, &pipeline_name)
-                } else {
-                    TriggerPipelineRequest::for_branch(&branch)
+                let mut variables = Vec::with_capacity(var.len() + secured_var.len());
+                for spec in &var {
+                    let (key, value) = parse_var(spec)?;
+                    variables.push(PipelineVariableInput {
+                        key,
+                        value,
+                        secured: false,
+                    });
+                }
+                for spec in &secured_var {
+                    let (key, value) = parse_var(spec)?;
+                    variables.push(PipelineVariableInput {
+                        key,
+                        value,
+                        secured: true,
+                    });
+                }
+                let variable_count = variables.len();
+
+                let mut request = match &commit {
+                    Some(hash) => TriggerPipelineRequest::for_commit(hash),
+                    None => TriggerPipelineRequest::for_branch(&branch),
                 };
+                if let Some(pipeline_name) = &pipeline {
+                    request = request.with_pipeline(pipeline_name);
+                }
+                request = request.with_variables(variables);
 
                 let triggered = client
                     .trigger_pipeline(&workspace, &repo_slug, &request)
                     .await?;
 
+                if super::output_json() {
+                    if wait {
+                        let done = wait_for_pipeline_silently(
+                            &client,
+                            &workspace,
+                            &repo_slug,
+                            &triggered.uuid,
+                        )
+                        .await?;
+                        return super::print_json(&done);
+                    }
+                    return super::print_json(&triggered);
+                }
+
+                let target_desc = match &commit {
+                    Some(hash) => format!("commit {}", hash.cyan()),
+                    None => format!("branch {}", branch.cyan()),
+                };
+                let variable_note = if variable_count > 0 {
+                    format!(" with {} variable(s)", variable_count)
+                } else {
+                    String::new()
+                };
                 println!(
-                    "{} Triggered pipeline #{} on branch {}",
+                    "{} Triggered pipeline #{} on {}{}",
                     "✓".green(),
                     triggered.build_number,
-                    branch.cyan()
+                    target_desc,
+                    variable_note
                 );
 
                 if wait {
                     println!();
-                    let pb = ProgressBar::new_spinner();
-                    pb.set_style(
-                        ProgressStyle::default_spinner()
-                            .template("{spinner:.blue} {msg}")
-                            .unwrap(),
-                    );
-                    pb.set_message("Waiting for pipeline to complete...");
-
-                    loop {
-                        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
-
-                        let current = client
-                            .get_pipeline(&workspace, &repo_slug, &triggered.uuid)
-                            .await?;
-
-                        match current.state.name {
-                            PipelineStateName::Completed => {
-                                pb.finish_and_clear();
-
-                                if let Some(result) = &current.state.result {
-                                    match result.name {
-                                        PipelineResultName::Successful => {
-                                            println!(
-                                                "{} Pipeline #{} completed successfully!",
-                                                "✓".green(),
-                                                current.build_number
-                                            );
-                                        }
-                                        PipelineResultName::Failed => {
-                                            println!(
-                                                "{} Pipeline #{} failed",
-                                                "✗".red(),
-                                                current.build_number
-                                            );
-                                        }
-                                        _ => {
-                                            println!(
-                                                "Pipeline #{} completed with status: {:?}",
-                                                current.build_number, result.name
-                                            );
-                                        }
-                                    }
-                                }
-                                break;
-                            }
-                            PipelineStateName::Halted => {
-                                pb.finish_and_clear();
-                                println!(
-                                    "{} Pipeline #{} was halted",
-                                    "⚠".yellow(),
-                                    current.build_number
-                                );
-                                break;
-                            }
-                            _ => {
-                                pb.tick();
-                            }
-                        }
-                    }
+                    wait_for_pipeline(&client, &workspace, &repo_slug, &triggered.uuid).await?;
                 }
 
                 Ok(())
             }
 
-            PipelineCommands::Stop { repo, build } => {
+            PipelineCommands::Stop { repo, build, uuid } => {
                 let (workspace, repo_slug) = parse_repo(&repo)?;
                 let client = BitbucketClient::from_stored().await?;
 
+                if let Some(uuid) = uuid {
+                    let uuid = ensure_braced_uuid(&uuid);
+                    client.stop_pipeline(&workspace, &repo_slug, &uuid).await?;
+                    if super::output_json() {
+                        return super::print_json(&serde_json::json!({"ok": true}));
+                    }
+                    println!("{} Stopped pipeline {}", "✓".green(), uuid);
+                    return Ok(());
+                }
+
+                // clap guarantees --build when --uuid is absent.
+                let build = build.expect("clap enforces --build or --uuid");
                 let pipeline = client
                     .get_pipeline_by_build_number(&workspace, &repo_slug, build)
                     .await?;
@@ -341,11 +676,798 @@ impl PipelineCommands {
                     .stop_pipeline(&workspace, &repo_slug, &pipeline.uuid)
                     .await?;
 
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
                 println!("{} Stopped pipeline #{}", "✓".green(), build);
 
                 Ok(())
             }
+
+            PipelineCommands::Rerun { repo, build } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let original = client
+                    .get_pipeline_by_build_number(&workspace, &repo_slug, build)
+                    .await?;
+
+                // Bitbucket has no rerun endpoint, so re-trigger an equivalent
+                // pipeline from the original's target.
+                let Some(ref_name) = original.target.ref_name.clone() else {
+                    anyhow::bail!(
+                        "Pipeline #{} has no branch to re-run from (target type '{}'). \
+                         Bitbucket has no rerun API, so only pipelines that ran against \
+                         a branch can be re-triggered. Use 'pipeline trigger' instead.",
+                        build,
+                        original.target.target_type
+                    );
+                };
+
+                let mut request = TriggerPipelineRequest::for_branch(&ref_name);
+                if let Some(selector) = &original.target.selector {
+                    if let Some(pattern) = &selector.pattern {
+                        request.target.selector = Some(TriggerPipelineSelector {
+                            selector_type: selector.selector_type.clone(),
+                            pattern: pattern.clone(),
+                        });
+                    }
+                }
+
+                let new = client
+                    .trigger_pipeline(&workspace, &repo_slug, &request)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&new);
+                }
+
+                println!(
+                    "{} Re-ran pipeline #{} as #{} on branch {}",
+                    "✓".green(),
+                    build,
+                    new.build_number,
+                    ref_name.cyan()
+                );
+
+                Ok(())
+            }
+
+            PipelineCommands::Config {
+                repo,
+                enable,
+                disable,
+                next_build_number,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                if super::output_json() {
+                    let mut config = None;
+                    if enable || disable {
+                        config = Some(
+                            client
+                                .update_pipelines_config_enabled(&workspace, &repo_slug, enable)
+                                .await?,
+                        );
+                    }
+                    if let Some(next) = next_build_number {
+                        client
+                            .set_pipelines_config_build_number(&workspace, &repo_slug, next)
+                            .await?;
+                    }
+                    return match config {
+                        Some(config) => super::print_json(&config),
+                        None if next_build_number.is_some() => {
+                            super::print_json(&serde_json::json!({"ok": true}))
+                        }
+                        None => super::print_json(
+                            &client.get_pipelines_config(&workspace, &repo_slug).await?,
+                        ),
+                    };
+                }
+
+                let mut changed = false;
+
+                if enable || disable {
+                    let config = client
+                        .update_pipelines_config_enabled(&workspace, &repo_slug, enable)
+                        .await?;
+                    let state = if config.enabled.unwrap_or(enable) {
+                        "enabled".green()
+                    } else {
+                        "disabled".red()
+                    };
+                    println!("{} Pipelines {} for {}", "✓".green(), state, repo);
+                    changed = true;
+                }
+
+                if let Some(next) = next_build_number {
+                    client
+                        .set_pipelines_config_build_number(&workspace, &repo_slug, next)
+                        .await?;
+                    println!("{} Next build number set to {}", "✓".green(), next);
+                    changed = true;
+                }
+
+                if !changed {
+                    let config = client.get_pipelines_config(&workspace, &repo_slug).await?;
+                    match config.enabled {
+                        Some(true) => println!("Pipelines are {} for {}", "enabled".green(), repo),
+                        Some(false) => println!("Pipelines are {} for {}", "disabled".red(), repo),
+                        None => println!("Pipelines enabled state is unknown for {}", repo),
+                    }
+                }
+
+                Ok(())
+            }
+
+            PipelineCommands::Variable { command } => command.run().await,
+            PipelineCommands::WorkspaceVariable { command } => command.run().await,
+            PipelineCommands::Schedule { command } => command.run().await,
+            PipelineCommands::Cache { command } => command.run().await,
         }
+    }
+}
+
+impl VariableCommands {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            VariableCommands::List { repo } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let variables = client
+                    .list_pipeline_variables(&workspace, &repo_slug)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&masked_variables(&variables));
+                }
+
+                if variables.is_empty() {
+                    println!("No pipeline variables found");
+                    return Ok(());
+                }
+
+                let table = Table::new(variable_rows(&variables)).to_string();
+                println!("{}", table);
+
+                Ok(())
+            }
+
+            VariableCommands::Set {
+                repo,
+                key,
+                value,
+                secured,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let input = PipelineVariableInput {
+                    key: key.clone(),
+                    value,
+                    secured,
+                };
+
+                let variables = client
+                    .list_pipeline_variables(&workspace, &repo_slug)
+                    .await?;
+                match find_variable_uuid(&variables, &key) {
+                    Some(uuid) => {
+                        let variable = client
+                            .update_pipeline_variable(&workspace, &repo_slug, &uuid, &input)
+                            .await
+                            .with_context(|| {
+                                format!(
+                                    "updating variable '{}' (it may have been deleted \
+                                     concurrently — re-run to create it)",
+                                    key
+                                )
+                            })?;
+                        if super::output_json() {
+                            return super::print_json(&variable);
+                        }
+                        println!("{} Updated pipeline variable {}", "✓".green(), key.cyan());
+                    }
+                    None => {
+                        let variable = client
+                            .create_pipeline_variable(&workspace, &repo_slug, &input)
+                            .await?;
+                        if super::output_json() {
+                            return super::print_json(&variable);
+                        }
+                        println!("{} Created pipeline variable {}", "✓".green(), key.cyan());
+                    }
+                }
+
+                Ok(())
+            }
+
+            VariableCommands::Delete { repo, key, yes } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let variables = client
+                    .list_pipeline_variables(&workspace, &repo_slug)
+                    .await?;
+                let uuid = find_variable_uuid(&variables, &key).ok_or_else(|| {
+                    anyhow::anyhow!("No pipeline variable named '{}' in {}", key, repo)
+                })?;
+
+                if !yes && !confirm_or_abort(format!("Delete pipeline variable {}?", key.red()))? {
+                    return Ok(());
+                }
+
+                client
+                    .delete_pipeline_variable(&workspace, &repo_slug, &uuid)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
+                println!("{} Deleted pipeline variable {}", "✓".green(), key);
+
+                Ok(())
+            }
+        }
+    }
+}
+
+impl WorkspaceVariableCommands {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            WorkspaceVariableCommands::List { workspace } => {
+                let workspace = resolve_workspace(workspace)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let variables = client.list_workspace_pipeline_variables(&workspace).await?;
+
+                if super::output_json() {
+                    return super::print_json(&masked_variables(&variables));
+                }
+
+                if variables.is_empty() {
+                    println!("No workspace pipeline variables found");
+                    return Ok(());
+                }
+
+                let table = Table::new(variable_rows(&variables)).to_string();
+                println!("{}", table);
+
+                Ok(())
+            }
+
+            WorkspaceVariableCommands::Set {
+                key,
+                value,
+                workspace,
+                secured,
+            } => {
+                let workspace = resolve_workspace(workspace)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let input = PipelineVariableInput {
+                    key: key.clone(),
+                    value,
+                    secured,
+                };
+
+                let variables = client.list_workspace_pipeline_variables(&workspace).await?;
+                match find_variable_uuid(&variables, &key) {
+                    Some(uuid) => {
+                        let variable = client
+                            .update_workspace_pipeline_variable(&workspace, &uuid, &input)
+                            .await
+                            .with_context(|| {
+                                format!(
+                                    "updating variable '{}' (it may have been deleted \
+                                     concurrently — re-run to create it)",
+                                    key
+                                )
+                            })?;
+                        if super::output_json() {
+                            return super::print_json(&variable);
+                        }
+                        println!(
+                            "{} Updated workspace pipeline variable {}",
+                            "✓".green(),
+                            key.cyan()
+                        );
+                    }
+                    None => {
+                        let variable = client
+                            .create_workspace_pipeline_variable(&workspace, &input)
+                            .await?;
+                        if super::output_json() {
+                            return super::print_json(&variable);
+                        }
+                        println!(
+                            "{} Created workspace pipeline variable {}",
+                            "✓".green(),
+                            key.cyan()
+                        );
+                    }
+                }
+
+                Ok(())
+            }
+
+            WorkspaceVariableCommands::Delete {
+                key,
+                workspace,
+                yes,
+            } => {
+                let workspace = resolve_workspace(workspace)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let variables = client.list_workspace_pipeline_variables(&workspace).await?;
+                let uuid = find_variable_uuid(&variables, &key).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "No workspace pipeline variable named '{}' in {}",
+                        key,
+                        workspace
+                    )
+                })?;
+
+                if !yes
+                    && !confirm_or_abort(format!(
+                        "Delete workspace pipeline variable {}?",
+                        key.red()
+                    ))?
+                {
+                    return Ok(());
+                }
+
+                client
+                    .delete_workspace_pipeline_variable(&workspace, &uuid)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
+                println!(
+                    "{} Deleted workspace pipeline variable {}",
+                    "✓".green(),
+                    key
+                );
+
+                Ok(())
+            }
+        }
+    }
+}
+
+impl ScheduleCommands {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            ScheduleCommands::List { repo } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let schedules = client
+                    .list_pipeline_schedules(&workspace, &repo_slug)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&schedules);
+                }
+
+                if schedules.is_empty() {
+                    println!("No pipeline schedules found");
+                    return Ok(());
+                }
+
+                let rows: Vec<ScheduleRow> = schedules
+                    .iter()
+                    .map(|s| ScheduleRow {
+                        enabled: if s.enabled.unwrap_or(false) {
+                            "yes".to_string()
+                        } else {
+                            "no".to_string()
+                        },
+                        cron: s.cron_pattern.clone().unwrap_or_else(|| "-".to_string()),
+                        branch: schedule_branch(s.target.as_ref()),
+                        uuid: s.uuid.clone(),
+                    })
+                    .collect();
+
+                let table = Table::new(rows).to_string();
+                println!("{}", table);
+
+                Ok(())
+            }
+
+            ScheduleCommands::Create { repo, branch, cron } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let schedule = client
+                    .create_pipeline_schedule(&workspace, &repo_slug, &branch, &cron)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&schedule);
+                }
+
+                println!(
+                    "{} Created schedule {} on branch {} ({})",
+                    "✓".green(),
+                    schedule.uuid,
+                    branch.cyan(),
+                    schedule.cron_pattern.as_deref().unwrap_or(&cron)
+                );
+
+                Ok(())
+            }
+
+            ScheduleCommands::Delete { repo, uuid, yes } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let uuid = ensure_braced_uuid(&uuid);
+
+                if !yes && !confirm_or_abort(format!("Delete pipeline schedule {}?", uuid.red()))? {
+                    return Ok(());
+                }
+
+                client
+                    .delete_pipeline_schedule(&workspace, &repo_slug, &uuid)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
+                println!("{} Deleted pipeline schedule {}", "✓".green(), uuid);
+
+                Ok(())
+            }
+        }
+    }
+}
+
+impl CacheCommands {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            CacheCommands::List { repo } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let caches = client.list_pipeline_caches(&workspace, &repo_slug).await?;
+
+                if super::output_json() {
+                    return super::print_json(&caches);
+                }
+
+                if caches.is_empty() {
+                    println!("No pipeline caches found");
+                    return Ok(());
+                }
+
+                let rows: Vec<CacheRow> = caches
+                    .iter()
+                    .map(|c| CacheRow {
+                        name: c.name.clone().unwrap_or_else(|| "-".to_string()),
+                        path: c.path.clone().unwrap_or_else(|| "-".to_string()),
+                        size: c
+                            .file_size_bytes
+                            .map(format_bytes)
+                            .unwrap_or_else(|| "-".to_string()),
+                        uuid: c.uuid.clone(),
+                    })
+                    .collect();
+
+                let table = Table::new(rows).to_string();
+                println!("{}", table);
+
+                Ok(())
+            }
+
+            CacheCommands::Delete { repo, name, yes } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let caches = client.list_pipeline_caches(&workspace, &repo_slug).await?;
+                let matches: Vec<_> = caches
+                    .into_iter()
+                    .filter(|c| c.name.as_deref() == Some(name.as_str()))
+                    .collect();
+
+                if matches.is_empty() {
+                    anyhow::bail!("No pipeline cache named '{}' in {}", name, repo);
+                }
+
+                if !yes
+                    && !confirm_or_abort(format!(
+                        "Delete {} pipeline cache(s) named {}?",
+                        matches.len(),
+                        name.red()
+                    ))?
+                {
+                    return Ok(());
+                }
+
+                let total = matches.len();
+                let json = super::output_json();
+                let mut deleted = 0usize;
+                let mut failures: Vec<(String, anyhow::Error)> = Vec::new();
+
+                // Delete every match rather than aborting on the first error, so
+                // a single bad cache doesn't leave the rest stranded.
+                for cache in &matches {
+                    match client
+                        .delete_pipeline_cache(&workspace, &repo_slug, &cache.uuid)
+                        .await
+                    {
+                        Ok(()) => {
+                            deleted += 1;
+                            if !json {
+                                println!("{} Deleted pipeline cache {}", "✓".green(), cache.uuid);
+                            }
+                        }
+                        Err(e) => failures.push((cache.uuid.clone(), e)),
+                    }
+                }
+
+                let failed = failures.len();
+
+                if failed > 0 {
+                    for (uuid, e) in &failures {
+                        eprintln!(
+                            "{} could not delete pipeline cache {}: {}",
+                            "⚠".yellow(),
+                            uuid,
+                            e
+                        );
+                    }
+                    anyhow::bail!(
+                        "Deleted {} of {} pipeline cache(s) named '{}' ({} failed)",
+                        deleted,
+                        total,
+                        name,
+                        failed
+                    );
+                }
+
+                if json {
+                    return super::print_json(&serde_json::json!({"ok": true, "deleted": deleted}));
+                }
+
+                println!(
+                    "{} Deleted {} of {} pipeline cache(s) named {}",
+                    "✓".green(),
+                    deleted,
+                    total,
+                    name
+                );
+
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Poll a pipeline every 5 seconds until it reaches a terminal state (same
+/// states as [`wait_for_pipeline`]) without any terminal output, and return
+/// the final pipeline for JSON rendering.
+async fn wait_for_pipeline_silently(
+    client: &BitbucketClient,
+    workspace: &str,
+    repo_slug: &str,
+    pipeline_uuid: &str,
+) -> Result<Pipeline> {
+    loop {
+        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+        let current = client
+            .get_pipeline(workspace, repo_slug, pipeline_uuid)
+            .await?;
+
+        match current.state.name {
+            PipelineStateName::Completed
+            | PipelineStateName::Halted
+            | PipelineStateName::Paused => return Ok(current),
+            _ => {}
+        }
+    }
+}
+
+/// Poll a pipeline every 5 seconds until it reaches a state where waiting is
+/// pointless: completed, halted, or paused (paused pipelines never progress
+/// without a manual resume in the Bitbucket UI, so treat them as terminal).
+async fn wait_for_pipeline(
+    client: &BitbucketClient,
+    workspace: &str,
+    repo_slug: &str,
+    pipeline_uuid: &str,
+) -> Result<()> {
+    let pb = ProgressBar::new_spinner();
+    pb.set_style(
+        ProgressStyle::default_spinner()
+            .template("{spinner:.blue} {msg}")
+            .unwrap(),
+    );
+    pb.set_message("Waiting for pipeline to complete...");
+
+    loop {
+        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+        let current = client
+            .get_pipeline(workspace, repo_slug, pipeline_uuid)
+            .await?;
+
+        match current.state.name {
+            PipelineStateName::Completed => {
+                pb.finish_and_clear();
+
+                if let Some(result) = &current.state.result {
+                    match result.name {
+                        PipelineResultName::Successful => {
+                            println!(
+                                "{} Pipeline #{} completed successfully!",
+                                "✓".green(),
+                                current.build_number
+                            );
+                        }
+                        PipelineResultName::Failed => {
+                            println!("{} Pipeline #{} failed", "✗".red(), current.build_number);
+                        }
+                        _ => {
+                            println!(
+                                "Pipeline #{} completed with status: {:?}",
+                                current.build_number, result.name
+                            );
+                        }
+                    }
+                }
+                break;
+            }
+            PipelineStateName::Halted => {
+                pb.finish_and_clear();
+                println!(
+                    "{} Pipeline #{} was halted",
+                    "⚠".yellow(),
+                    current.build_number
+                );
+                break;
+            }
+            PipelineStateName::Paused => {
+                pb.finish_and_clear();
+                println!(
+                    "{} Pipeline #{} is PAUSED and requires manual resume",
+                    "⚠".yellow(),
+                    current.build_number
+                );
+                break;
+            }
+            _ => {
+                pb.tick();
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Fetch and print a step's log, indented and dimmed. Without `full`, output
+/// is truncated to the first 50 lines.
+///
+/// Returns any fetch error to the caller instead of swallowing it. An empty
+/// log is treated as success (logs may simply not exist yet for pending or
+/// in-progress steps): callers iterating over every step ignore the error,
+/// while a caller that explicitly asked for one step surfaces it.
+async fn print_step_log(
+    client: &BitbucketClient,
+    workspace: &str,
+    repo_slug: &str,
+    pipeline_uuid: &str,
+    step_uuid: &str,
+    full: bool,
+) -> Result<()> {
+    let log = client
+        .get_step_log(workspace, repo_slug, pipeline_uuid, step_uuid)
+        .await?;
+
+    if log.is_empty() {
+        return Ok(());
+    }
+
+    println!();
+    if full {
+        for line in log.lines() {
+            println!("    {}", line.dimmed());
+        }
+    } else {
+        let (shown, truncated) = take_log_lines(&log, 50);
+        for line in shown {
+            println!("    {}", line.dimmed());
+        }
+        if truncated {
+            println!(
+                "    {}",
+                "... (truncated; use --full-logs for the complete log)".dimmed()
+            );
+        }
+    }
+    println!();
+
+    Ok(())
+}
+
+/// Print the detail block for a single pipeline step.
+fn print_step_detail(step: &PipelineStep) {
+    println!();
+    println!("{}", "Step:".bold());
+    println!(
+        "  {} {}",
+        step_status_icon(step),
+        step.name.as_deref().unwrap_or("Step")
+    );
+    println!("    {} {}", "UUID:".dimmed(), step.uuid);
+
+    if let Some(state) = &step.state {
+        let result = state
+            .result
+            .as_ref()
+            .map(|r| format!(" ({})", r.name))
+            .unwrap_or_default();
+        println!("    {} {}{}", "State:".dimmed(), state.name, result);
+    }
+
+    if let Some(started) = step.started_on {
+        println!(
+            "    {} {}",
+            "Started:".dimmed(),
+            started.format("%Y-%m-%d %H:%M:%S")
+        );
+    }
+
+    if let Some(completed) = step.completed_on {
+        println!(
+            "    {} {}",
+            "Completed:".dimmed(),
+            completed.format("%Y-%m-%d %H:%M:%S")
+        );
+    }
+
+    if let Some(image) = &step.image {
+        println!("    {} {}", "Image:".dimmed(), image.name);
+    }
+
+    if let Some(commands) = &step.script_commands {
+        println!("    {} {}", "Script commands:".dimmed(), commands.len());
+    }
+}
+
+/// Status icon for a pipeline step based on its state and result.
+fn step_status_icon(step: &PipelineStep) -> ColoredString {
+    let status = step
+        .state
+        .as_ref()
+        .map(|s| s.name.as_str())
+        .unwrap_or("unknown");
+
+    match status {
+        "COMPLETED" => {
+            let result = step
+                .state
+                .as_ref()
+                .and_then(|s| s.result.as_ref())
+                .map(|r| r.name.as_str())
+                .unwrap_or("");
+            match result {
+                "SUCCESSFUL" => "✓".green(),
+                "FAILED" => "✗".red(),
+                _ => "○".normal(),
+            }
+        }
+        "IN_PROGRESS" => "◉".blue(),
+        "PENDING" => "○".dimmed(),
+        _ => "○".normal(),
     }
 }
 
@@ -384,6 +1506,150 @@ pub(crate) fn format_duration(seconds: u64) -> String {
     }
 }
 
+/// Split a `KEY=VALUE` argument on the FIRST '=' so values may contain '='.
+fn parse_var(spec: &str) -> Result<(String, String)> {
+    let (key, value) = spec
+        .split_once('=')
+        .ok_or_else(|| anyhow::anyhow!("Invalid variable '{}': expected KEY=VALUE", spec))?;
+
+    if key.is_empty() {
+        anyhow::bail!("Invalid variable '{}': key must not be empty", spec);
+    }
+
+    Ok((key.to_string(), value.to_string()))
+}
+
+/// Resolve a `--step` selector against a pipeline's steps.
+///
+/// A selector that parses as a number is a 1-based index; anything else is
+/// matched as a case-insensitive UUID prefix (braces optional). Returns the
+/// zero-based index of the step and whether it was selected by UUID.
+fn select_step(steps: &[PipelineStep], selector: &str) -> Result<(usize, bool)> {
+    if let Ok(index) = selector.parse::<usize>() {
+        if index == 0 || index > steps.len() {
+            anyhow::bail!(
+                "Step index {} out of range (pipeline has {} step(s))",
+                index,
+                steps.len()
+            );
+        }
+        return Ok((index - 1, false));
+    }
+
+    let clean = |s: &str| {
+        s.trim_start_matches('{')
+            .trim_end_matches('}')
+            .to_lowercase()
+    };
+    let needle = clean(selector);
+    if needle.is_empty() {
+        anyhow::bail!("--step must be a 1-based index or a step UUID prefix");
+    }
+
+    let matches: Vec<usize> = steps
+        .iter()
+        .enumerate()
+        .filter(|(_, s)| clean(&s.uuid).starts_with(&needle))
+        .map(|(i, _)| i)
+        .collect();
+
+    match matches.as_slice() {
+        [] => anyhow::bail!("No step matches '{}'", selector),
+        [only] => Ok((*only, true)),
+        _ => anyhow::bail!(
+            "Step UUID prefix '{}' is ambiguous ({} steps match)",
+            selector,
+            matches.len()
+        ),
+    }
+}
+
+/// Wrap a UUID in braces if the user omitted them; Bitbucket API paths
+/// require the braced form.
+fn ensure_braced_uuid(uuid: &str) -> String {
+    let uuid = uuid.trim();
+    let trimmed = uuid.trim_start_matches('{').trim_end_matches('}');
+    format!("{{{}}}", trimmed)
+}
+
+/// Find the UUID of the variable whose key matches exactly.
+fn find_variable_uuid(variables: &[PipelineVariable], key: &str) -> Option<String> {
+    variables
+        .iter()
+        .find(|v| v.key.as_deref() == Some(key))
+        .and_then(|v| v.uuid.clone())
+}
+
+/// Return a copy of `variables` with secured values nulled out.
+///
+/// The API already omits `value` for secured variables, but this defends the
+/// JSON path so a future/API quirk can't leak a secret that the table view
+/// would have masked.
+fn masked_variables(variables: &[PipelineVariable]) -> Vec<PipelineVariable> {
+    variables
+        .iter()
+        .map(|v| {
+            let mut masked = v.clone();
+            if masked.secured == Some(true) {
+                masked.value = None;
+            }
+            masked
+        })
+        .collect()
+}
+
+/// Table rows for repository or workspace pipeline variables. Secured values
+/// are never returned by the API, so they render masked.
+fn variable_rows(variables: &[PipelineVariable]) -> Vec<VariableRow> {
+    variables
+        .iter()
+        .map(|v| {
+            let secured = v.secured.unwrap_or(false);
+            VariableRow {
+                key: v.key.clone().unwrap_or_else(|| "-".to_string()),
+                value: if secured {
+                    "••••••".to_string()
+                } else {
+                    v.value.clone().unwrap_or_else(|| "-".to_string())
+                },
+                secured: if secured {
+                    "yes".to_string()
+                } else {
+                    "no".to_string()
+                },
+                uuid: v.uuid.clone().unwrap_or_else(|| "-".to_string()),
+            }
+        })
+        .collect()
+}
+
+/// Extract the branch name from a schedule's raw target object.
+fn schedule_branch(target: Option<&serde_json::Value>) -> String {
+    target
+        .and_then(|t| t.get("ref_name"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("-")
+        .to_string()
+}
+
+/// Human-readable byte size using binary units.
+fn format_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+
+    if unit == 0 {
+        format!("{} B", bytes)
+    } else {
+        format!("{:.1} {}", value, UNITS[unit])
+    }
+}
+
 /// Take at most `max` display lines from a log in a single pass, reporting
 /// whether any lines were left out.
 fn take_log_lines(log: &str, max: usize) -> (Vec<&str>, bool) {
@@ -395,7 +1661,12 @@ fn take_log_lines(log: &str, max: usize) -> (Vec<&str>, bool) {
 
 #[cfg(test)]
 mod tests {
-    use super::take_log_lines;
+    use crate::models::{PipelineStep, PipelineStepResult, PipelineStepState, PipelineVariable};
+
+    use super::{
+        ensure_braced_uuid, find_variable_uuid, format_bytes, parse_var, schedule_branch,
+        select_step, step_status_icon, take_log_lines, variable_rows,
+    };
 
     fn log_with_lines(n: usize) -> String {
         (0..n).map(|i| format!("line {}\n", i)).collect()
@@ -423,5 +1694,236 @@ mod tests {
         let (shown, truncated) = take_log_lines(&log, 50);
         assert_eq!(shown.len(), 50);
         assert!(truncated);
+    }
+
+    #[test]
+    fn parse_var_splits_on_first_equals() {
+        let (key, value) = parse_var("KEY=a=b=c").unwrap();
+        assert_eq!(key, "KEY");
+        assert_eq!(value, "a=b=c");
+    }
+
+    #[test]
+    fn parse_var_accepts_empty_value() {
+        let (key, value) = parse_var("KEY=").unwrap();
+        assert_eq!(key, "KEY");
+        assert_eq!(value, "");
+    }
+
+    #[test]
+    fn parse_var_rejects_missing_equals() {
+        let err = parse_var("KEYVALUE").unwrap_err();
+        assert!(err.to_string().contains("expected KEY=VALUE"));
+    }
+
+    #[test]
+    fn parse_var_rejects_empty_key() {
+        let err = parse_var("=value").unwrap_err();
+        assert!(err.to_string().contains("key must not be empty"));
+    }
+
+    fn step(uuid: &str) -> PipelineStep {
+        PipelineStep {
+            uuid: uuid.to_string(),
+            name: Some("Step".to_string()),
+            started_on: None,
+            completed_on: None,
+            state: None,
+            image: None,
+            setup_commands: None,
+            script_commands: None,
+            links: None,
+        }
+    }
+
+    #[test]
+    fn select_step_by_one_based_index() {
+        let steps = [step("{aaa-111}"), step("{bbb-222}")];
+        let (index, by_uuid) = select_step(&steps, "2").unwrap();
+        assert_eq!(index, 1);
+        assert!(!by_uuid);
+    }
+
+    #[test]
+    fn select_step_rejects_index_zero() {
+        let steps = [step("{aaa-111}")];
+        assert!(select_step(&steps, "0").is_err());
+    }
+
+    #[test]
+    fn select_step_rejects_index_out_of_range() {
+        let steps = [step("{aaa-111}")];
+        assert!(select_step(&steps, "2").is_err());
+    }
+
+    #[test]
+    fn select_step_by_uuid_prefix_without_braces() {
+        let steps = [step("{aaa-111}"), step("{bbb-222}")];
+        let (index, by_uuid) = select_step(&steps, "bbb").unwrap();
+        assert_eq!(index, 1);
+        assert!(by_uuid);
+    }
+
+    #[test]
+    fn select_step_by_full_braced_uuid() {
+        let steps = [step("{aaa-111}"), step("{bbb-222}")];
+        let (index, by_uuid) = select_step(&steps, "{bbb-222}").unwrap();
+        assert_eq!(index, 1);
+        assert!(by_uuid);
+    }
+
+    #[test]
+    fn select_step_uuid_prefix_is_case_insensitive() {
+        let steps = [step("{ABC-123}")];
+        let (index, _) = select_step(&steps, "abc").unwrap();
+        assert_eq!(index, 0);
+    }
+
+    #[test]
+    fn select_step_rejects_ambiguous_prefix() {
+        let steps = [step("{abc-111}"), step("{abc-222}")];
+        let err = select_step(&steps, "abc").unwrap_err();
+        assert!(err.to_string().contains("ambiguous"));
+    }
+
+    #[test]
+    fn select_step_rejects_unknown_prefix() {
+        let steps = [step("{aaa-111}")];
+        assert!(select_step(&steps, "zzz").is_err());
+    }
+
+    #[test]
+    fn ensure_braced_uuid_wraps_bare_uuids() {
+        assert_eq!(ensure_braced_uuid("abc-123"), "{abc-123}");
+    }
+
+    #[test]
+    fn ensure_braced_uuid_keeps_braced_uuids() {
+        assert_eq!(ensure_braced_uuid("{abc-123}"), "{abc-123}");
+    }
+
+    #[test]
+    fn find_variable_uuid_matches_key_exactly() {
+        let variables = vec![
+            crate::models::PipelineVariable {
+                uuid: Some("{u1}".to_string()),
+                key: Some("FOO".to_string()),
+                value: None,
+                secured: None,
+            },
+            crate::models::PipelineVariable {
+                uuid: Some("{u2}".to_string()),
+                key: Some("FOOBAR".to_string()),
+                value: None,
+                secured: None,
+            },
+        ];
+
+        assert_eq!(
+            find_variable_uuid(&variables, "FOO").as_deref(),
+            Some("{u1}")
+        );
+        assert_eq!(find_variable_uuid(&variables, "BAR"), None);
+    }
+
+    #[test]
+    fn schedule_branch_reads_ref_name_from_target() {
+        let target = serde_json::json!({"type": "pipeline_ref_target", "ref_name": "main"});
+        assert_eq!(schedule_branch(Some(&target)), "main");
+    }
+
+    #[test]
+    fn schedule_branch_falls_back_to_dash() {
+        assert_eq!(schedule_branch(None), "-");
+        let target = serde_json::json!({"type": "pipeline_ref_target"});
+        assert_eq!(schedule_branch(Some(&target)), "-");
+    }
+
+    #[test]
+    fn format_bytes_uses_binary_units() {
+        assert_eq!(format_bytes(512), "512 B");
+        assert_eq!(format_bytes(2048), "2.0 KiB");
+        assert_eq!(format_bytes(5 * 1024 * 1024), "5.0 MiB");
+    }
+
+    fn step_with_state(state: &str, result: Option<&str>) -> PipelineStep {
+        PipelineStep {
+            uuid: "{step}".to_string(),
+            name: Some("Step".to_string()),
+            started_on: None,
+            completed_on: None,
+            state: Some(PipelineStepState {
+                name: state.to_string(),
+                state_type: "pipeline_step_state".to_string(),
+                result: result.map(|r| PipelineStepResult {
+                    name: r.to_string(),
+                    result_type: "pipeline_step_result".to_string(),
+                }),
+            }),
+            image: None,
+            setup_commands: None,
+            script_commands: None,
+            links: None,
+        }
+    }
+
+    #[test]
+    fn step_status_icon_per_state() {
+        // Assert on the underlying glyph via `contains` so the result holds
+        // whether or not ANSI colouring is active in the test environment.
+        assert!(
+            step_status_icon(&step_with_state("COMPLETED", Some("SUCCESSFUL")))
+                .to_string()
+                .contains('✓')
+        );
+        assert!(
+            step_status_icon(&step_with_state("COMPLETED", Some("FAILED")))
+                .to_string()
+                .contains('✗')
+        );
+        assert!(
+            step_status_icon(&step_with_state("COMPLETED", Some("STOPPED")))
+                .to_string()
+                .contains('○')
+        );
+        assert!(
+            step_status_icon(&step_with_state("IN_PROGRESS", None))
+                .to_string()
+                .contains('◉')
+        );
+        assert!(
+            step_status_icon(&step_with_state("PENDING", None))
+                .to_string()
+                .contains('○')
+        );
+
+        // No state at all falls back to the neutral marker.
+        let mut stateless = step_with_state("PENDING", None);
+        stateless.state = None;
+        assert!(step_status_icon(&stateless).to_string().contains('○'));
+    }
+
+    fn variable(key: &str, value: Option<&str>, secured: Option<bool>) -> PipelineVariable {
+        PipelineVariable {
+            uuid: Some("{u}".to_string()),
+            key: Some(key.to_string()),
+            value: value.map(|v| v.to_string()),
+            secured,
+        }
+    }
+
+    #[test]
+    fn variable_rows_masks_secured_values() {
+        let vars = vec![
+            variable("PLAIN", Some("hello"), Some(false)),
+            variable("SECRET", Some("shh"), Some(true)),
+        ];
+        let rows = variable_rows(&vars);
+
+        assert_eq!(rows[0].value, "hello");
+        assert_eq!(rows[0].secured, "no");
+
+        assert_eq!(rows[1].value, "••••••");
+        assert_eq!(rows[1].secured, "yes");
     }
 }

--- a/src/cli/pr.rs
+++ b/src/cli/pr.rs
@@ -5,9 +5,11 @@ use tabled::{Table, Tabled};
 
 use super::parse_repo;
 use crate::api::BitbucketClient;
+use crate::cli::pagination::effective_limit;
 use crate::models::{
-    BranchInfo, CreatePullRequestRequest, MergePullRequestRequest, MergeStrategy,
-    PullRequestBranchRef, PullRequestComment, PullRequestState,
+    BranchInfo, CreatePullRequestRequest, MergePullRequestRequest, MergeStrategy, PrActivity,
+    PullRequest, PullRequestBranchRef, PullRequestComment, PullRequestState,
+    UpdatePullRequestRequest, UserRef,
 };
 
 #[derive(Subcommand)]
@@ -17,9 +19,21 @@ pub enum PrCommands {
         /// Repository in format workspace/repo-slug
         repo: String,
 
-        /// Filter by state
+        /// Filter by state (repeatable to match several states)
         #[arg(short, long, value_enum)]
-        state: Option<PrState>,
+        state: Vec<PrState>,
+
+        /// Filter with a Bitbucket query (BBQL) expression
+        #[arg(short = 'q', long)]
+        query: Option<String>,
+
+        /// Sort field (e.g. -updated_on)
+        #[arg(long)]
+        sort: Option<String>,
+
+        /// Page number to fetch
+        #[arg(long)]
+        page: Option<u32>,
 
         /// Number of results
         #[arg(short, long, default_value = "25")]
@@ -63,6 +77,35 @@ pub enum PrCommands {
         /// Close source branch after merge
         #[arg(long)]
         close_source_branch: bool,
+
+        /// Comma-separated reviewer account IDs, UUIDs, or usernames
+        #[arg(long)]
+        reviewers: Option<String>,
+    },
+
+    /// Edit an existing pull request
+    Edit {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        id: u64,
+
+        /// New title
+        #[arg(short, long)]
+        title: Option<String>,
+
+        /// New description
+        #[arg(short = 'b', long)]
+        body: Option<String>,
+
+        /// Comma-separated reviewer account IDs, UUIDs, or usernames (replaces the reviewer list)
+        #[arg(long)]
+        reviewers: Option<String>,
+
+        /// New destination branch
+        #[arg(short, long)]
+        destination: Option<String>,
     },
 
     /// Merge a pull request
@@ -88,6 +131,33 @@ pub enum PrCommands {
 
     /// Approve a pull request
     Approve {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        id: u64,
+    },
+
+    /// Remove your approval from a pull request
+    Unapprove {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        id: u64,
+    },
+
+    /// Request changes on a pull request
+    RequestChanges {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        id: u64,
+    },
+
+    /// Withdraw your request for changes on a pull request
+    UnrequestChanges {
         /// Repository in format workspace/repo-slug
         repo: String,
 
@@ -133,6 +203,78 @@ pub enum PrCommands {
         /// Comment text
         #[arg(short, long)]
         body: String,
+
+        /// File path for an inline comment
+        #[arg(long)]
+        path: Option<String>,
+
+        /// Line number for an inline comment (requires --path)
+        #[arg(long, requires = "path")]
+        line: Option<u32>,
+
+        /// Parent comment ID to reply to
+        #[arg(long)]
+        parent: Option<u64>,
+    },
+
+    /// Edit a comment on a pull request
+    EditComment {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        #[arg(value_name = "PR_ID")]
+        id: u64,
+
+        /// Comment ID
+        comment_id: u64,
+
+        /// New comment text
+        #[arg(short, long)]
+        body: String,
+    },
+
+    /// Delete a comment on a pull request
+    DeleteComment {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        #[arg(value_name = "PR_ID")]
+        id: u64,
+
+        /// Comment ID
+        comment_id: u64,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+
+    /// Resolve a comment thread on a pull request
+    ResolveComment {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        #[arg(value_name = "PR_ID")]
+        id: u64,
+
+        /// Comment ID
+        comment_id: u64,
+    },
+
+    /// Reopen a resolved comment thread on a pull request
+    UnresolveComment {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        #[arg(value_name = "PR_ID")]
+        id: u64,
+
+        /// Comment ID
+        comment_id: u64,
     },
 
     /// List comments on a pull request
@@ -172,6 +314,138 @@ pub enum PrCommands {
         /// Maximum recent pipelines to scan for matches (capped at 100)
         #[arg(short, long, default_value = "100")]
         scan_limit: u32,
+    },
+
+    /// List commits on a pull request
+    Commits {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        id: u64,
+
+        /// Number of results
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+    },
+
+    /// Show build statuses for a pull request
+    Statuses {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        id: u64,
+    },
+
+    /// Show the per-file change summary for a pull request
+    Diffstat {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        id: u64,
+
+        /// Number of results
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+    },
+
+    /// Manage tasks on a pull request
+    Task {
+        #[command(subcommand)]
+        command: TaskCommands,
+    },
+
+    /// Show the activity feed for a pull request
+    Activity {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        id: u64,
+
+        /// Number of results
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+    },
+
+    /// Print the patch (mbox-style) for a pull request
+    Patch {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        id: u64,
+    },
+}
+
+/// Subcommands for `pr task`
+#[derive(Subcommand)]
+pub enum TaskCommands {
+    /// List tasks on a pull request
+    List {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        id: u64,
+    },
+
+    /// Add a task to a pull request
+    Add {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        id: u64,
+
+        /// Task text
+        #[arg(short, long)]
+        body: String,
+    },
+
+    /// Mark a task as resolved
+    Resolve {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        #[arg(value_name = "PR_ID")]
+        id: u64,
+
+        /// Task ID
+        task_id: u64,
+    },
+
+    /// Reopen a resolved task
+    Reopen {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        #[arg(value_name = "PR_ID")]
+        id: u64,
+
+        /// Task ID
+        task_id: u64,
+    },
+
+    /// Delete a task from a pull request
+    Delete {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Pull request ID
+        #[arg(value_name = "PR_ID")]
+        id: u64,
+
+        /// Task ID
+        task_id: u64,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
     },
 }
 
@@ -242,6 +516,50 @@ struct PipelineRow {
 }
 
 #[derive(Tabled)]
+struct CommitRow {
+    #[tabled(rename = "HASH")]
+    hash: String,
+    #[tabled(rename = "DATE")]
+    date: String,
+    #[tabled(rename = "MESSAGE")]
+    message: String,
+}
+
+#[derive(Tabled)]
+struct StatusRow {
+    #[tabled(rename = "KEY")]
+    key: String,
+    #[tabled(rename = "NAME")]
+    name: String,
+    #[tabled(rename = "STATE")]
+    state: String,
+    #[tabled(rename = "URL")]
+    url: String,
+}
+
+#[derive(Tabled)]
+struct DiffstatRow {
+    #[tabled(rename = "STATUS")]
+    status: String,
+    #[tabled(rename = "FILE")]
+    file: String,
+    #[tabled(rename = "+")]
+    added: String,
+    #[tabled(rename = "-")]
+    removed: String,
+}
+
+#[derive(Tabled)]
+struct TaskRow {
+    #[tabled(rename = "ID")]
+    id: String,
+    #[tabled(rename = "STATE")]
+    state: String,
+    #[tabled(rename = "TASK")]
+    content: String,
+}
+
+#[derive(Tabled)]
 struct CommentRow {
     #[tabled(rename = "ID")]
     id: u64,
@@ -258,19 +576,35 @@ struct CommentRow {
 impl PrCommands {
     pub async fn run(self) -> Result<()> {
         match self {
-            PrCommands::List { repo, state, limit } => {
+            PrCommands::List {
+                repo,
+                state,
+                query,
+                sort,
+                page,
+                limit,
+            } => {
                 let (workspace, repo_slug) = parse_repo(&repo)?;
                 let client = BitbucketClient::from_stored().await?;
 
+                let states: Vec<PullRequestState> = state.into_iter().map(Into::into).collect();
                 let prs = client
-                    .list_pull_requests(
+                    .list_pull_requests_filtered(
                         &workspace,
                         &repo_slug,
-                        state.map(|s| s.into()),
-                        None,
-                        Some(limit),
+                        crate::api::pullrequests::PrListFilters {
+                            states: &states,
+                            query: query.as_deref(),
+                            sort: sort.as_deref(),
+                            page,
+                            pagelen: Some(limit.clamp(1, 100)),
+                        },
                     )
                     .await?;
+
+                if super::output_json() {
+                    return super::print_json(&prs.values);
+                }
 
                 if prs.values.is_empty() {
                     println!("No pull requests found");
@@ -292,6 +626,13 @@ impl PrCommands {
                 let table = Table::new(rows).to_string();
                 println!("{}", table);
 
+                if prs.next.is_some() {
+                    println!(
+                        "{} More pull requests available; use --page/--limit to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
                 Ok(())
             }
 
@@ -309,6 +650,10 @@ impl PrCommands {
                         }
                     }
                     anyhow::bail!("Could not find PR URL");
+                }
+
+                if super::output_json() {
+                    return super::print_json(&pr);
                 }
 
                 println!("{} {} #{}", format_state(&pr.state), pr.title.bold(), pr.id);
@@ -383,6 +728,7 @@ impl PrCommands {
                 destination,
                 body,
                 close_source_branch,
+                reviewers,
             } => {
                 let (workspace, repo_slug) = parse_repo(&repo)?;
                 let client = BitbucketClient::from_stored().await?;
@@ -397,12 +743,16 @@ impl PrCommands {
                     }),
                     description: body,
                     close_source_branch: Some(close_source_branch),
-                    reviewers: None,
+                    reviewers: reviewers.as_deref().map(parse_reviewers),
                 };
 
                 let pr = client
                     .create_pull_request(&workspace, &repo_slug, &request)
                     .await?;
+
+                if super::output_json() {
+                    return super::print_json(&pr);
+                }
 
                 println!("{} Created pull request #{}", "✓".green(), pr.id);
 
@@ -411,6 +761,45 @@ impl PrCommands {
                         println!("{} {}", "URL:".dimmed(), html.href.cyan());
                     }
                 }
+
+                Ok(())
+            }
+
+            PrCommands::Edit {
+                repo,
+                id,
+                title,
+                body,
+                reviewers,
+                destination,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                let request = UpdatePullRequestRequest {
+                    title,
+                    description: body,
+                    reviewers: reviewers.as_deref().map(parse_reviewers),
+                    destination: destination.map(|d| PullRequestBranchRef {
+                        branch: BranchInfo { name: d },
+                    }),
+                };
+
+                if request.is_empty() {
+                    anyhow::bail!(
+                        "Nothing to edit: pass at least one of --title, --body, --reviewers, or --destination"
+                    );
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                let pr = client
+                    .update_pull_request(&workspace, &repo_slug, id, &request)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&pr);
+                }
+
+                println!("{} Updated pull request #{}", "✓".green(), pr.id);
 
                 Ok(())
             }
@@ -436,6 +825,10 @@ impl PrCommands {
                     .merge_pull_request(&workspace, &repo_slug, id, Some(&request))
                     .await?;
 
+                if super::output_json() {
+                    return super::print_json(&pr);
+                }
+
                 println!("{} Merged pull request #{}", "✓".green(), pr.id);
 
                 Ok(())
@@ -449,7 +842,66 @@ impl PrCommands {
                     .approve_pull_request(&workspace, &repo_slug, id)
                     .await?;
 
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
                 println!("{} Approved pull request #{}", "✓".green(), id);
+
+                Ok(())
+            }
+
+            PrCommands::Unapprove { repo, id } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                client
+                    .unapprove_pull_request(&workspace, &repo_slug, id)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
+                println!("{} Removed approval from pull request #{}", "✓".green(), id);
+
+                Ok(())
+            }
+
+            PrCommands::RequestChanges { repo, id } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                client
+                    .request_pr_changes(&workspace, &repo_slug, id)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
+                println!("{} Requested changes on pull request #{}", "✓".green(), id);
+
+                Ok(())
+            }
+
+            PrCommands::UnrequestChanges { repo, id } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                client
+                    .unrequest_pr_changes(&workspace, &repo_slug, id)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
+                println!(
+                    "{} Withdrew request for changes on pull request #{}",
+                    "✓".green(),
+                    id
+                );
 
                 Ok(())
             }
@@ -458,9 +910,13 @@ impl PrCommands {
                 let (workspace, repo_slug) = parse_repo(&repo)?;
                 let client = BitbucketClient::from_stored().await?;
 
-                client
+                let pr = client
                     .decline_pull_request(&workspace, &repo_slug, id)
                     .await?;
+
+                if super::output_json() {
+                    return super::print_json(&pr);
+                }
 
                 println!("{} Declined pull request #{}", "✓".green(), id);
 
@@ -472,43 +928,7 @@ impl PrCommands {
                 let client = BitbucketClient::from_stored().await?;
 
                 let pr = client.get_pull_request(&workspace, &repo_slug, id).await?;
-                let branch = &pr.source.branch.name;
-
-                println!("Fetching and checking out branch {}...", branch.cyan());
-
-                // Fetch the branch
-                let status = std::process::Command::new("git")
-                    .args(["fetch", "origin", branch])
-                    .status()
-                    .context("Failed to fetch branch")?;
-
-                if !status.success() {
-                    anyhow::bail!("git fetch failed");
-                }
-
-                // Checkout the branch
-                let status = std::process::Command::new("git")
-                    .args(["checkout", branch])
-                    .status()
-                    .context("Failed to checkout branch")?;
-
-                if status.success() {
-                    println!("{} Checked out branch {}", "✓".green(), branch);
-                } else {
-                    // Try creating a tracking branch
-                    let status = std::process::Command::new("git")
-                        .args(["checkout", "-b", branch, &format!("origin/{}", branch)])
-                        .status()
-                        .context("Failed to create tracking branch")?;
-
-                    if status.success() {
-                        println!("{} Created and checked out branch {}", "✓".green(), branch);
-                    } else {
-                        anyhow::bail!("git checkout failed");
-                    }
-                }
-
-                Ok(())
+                checkout_pr_branch(&pr, &workspace, &repo_slug).await
             }
 
             PrCommands::Diff { repo, id } => {
@@ -521,15 +941,151 @@ impl PrCommands {
                 Ok(())
             }
 
-            PrCommands::Comment { repo, id, body } => {
+            PrCommands::Comment {
+                repo,
+                id,
+                body,
+                path,
+                line,
+                parent,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let comment = client
+                    .add_pr_comment_full(
+                        &workspace,
+                        &repo_slug,
+                        id,
+                        crate::api::pullrequests::PrCommentInput {
+                            content: &body,
+                            path: path.as_deref(),
+                            line,
+                            parent,
+                        },
+                    )
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&comment);
+                }
+
+                println!("{} Added comment to pull request #{}", "✓".green(), id);
+
+                Ok(())
+            }
+
+            PrCommands::EditComment {
+                repo,
+                id,
+                comment_id,
+                body,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let comment = client
+                    .update_pr_comment(&workspace, &repo_slug, id, comment_id, &body)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&comment);
+                }
+
+                println!(
+                    "{} Updated comment #{} on pull request #{}",
+                    "✓".green(),
+                    comment_id,
+                    id
+                );
+
+                Ok(())
+            }
+
+            PrCommands::DeleteComment {
+                repo,
+                id,
+                comment_id,
+                yes,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                if !yes
+                    && !super::confirm_or_abort(format!(
+                        "Delete comment #{} on PR #{}?",
+                        comment_id, id
+                    ))?
+                {
+                    return Ok(());
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                client
+                    .delete_pr_comment(&workspace, &repo_slug, id, comment_id)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
+                println!(
+                    "{} Deleted comment #{} from pull request #{}",
+                    "✓".green(),
+                    comment_id,
+                    id
+                );
+
+                Ok(())
+            }
+
+            PrCommands::ResolveComment {
+                repo,
+                id,
+                comment_id,
+            } => {
                 let (workspace, repo_slug) = parse_repo(&repo)?;
                 let client = BitbucketClient::from_stored().await?;
 
                 client
-                    .add_pr_comment(&workspace, &repo_slug, id, &body)
+                    .resolve_pr_comment(&workspace, &repo_slug, id, comment_id)
                     .await?;
 
-                println!("{} Added comment to pull request #{}", "✓".green(), id);
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
+                println!(
+                    "{} Resolved comment thread #{} on pull request #{}",
+                    "✓".green(),
+                    comment_id,
+                    id
+                );
+
+                Ok(())
+            }
+
+            PrCommands::UnresolveComment {
+                repo,
+                id,
+                comment_id,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                client
+                    .unresolve_pr_comment(&workspace, &repo_slug, id, comment_id)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
+                println!(
+                    "{} Reopened comment thread #{} on pull request #{}",
+                    "✓".green(),
+                    comment_id,
+                    id
+                );
 
                 Ok(())
             }
@@ -541,6 +1097,13 @@ impl PrCommands {
                 let comments = client
                     .list_recent_pr_comments(&workspace, &repo_slug, id, limit as usize)
                     .await?;
+
+                if super::output_json() {
+                    return super::print_json(&newest_comments_chronological(
+                        comments,
+                        limit as usize,
+                    ));
+                }
 
                 if comments.is_empty() {
                     println!("No comments found");
@@ -597,6 +1160,10 @@ impl PrCommands {
                 let pipelines = client
                     .list_pipelines_for_commit(&workspace, &repo_slug, &head_commit, scan_limit)
                     .await?;
+
+                if super::output_json() {
+                    return super::print_json(&pipelines);
+                }
 
                 if pipelines.is_empty() {
                     println!(
@@ -655,6 +1222,10 @@ impl PrCommands {
                     .get_pr_comment(&workspace, &repo_slug, id, comment_id)
                     .await?;
 
+                if super::output_json() {
+                    return super::print_json(&comment);
+                }
+
                 println!("{} #{} on PR #{}", "Comment".bold(), comment.id, id);
                 println!("{}", "─".repeat(60));
 
@@ -697,6 +1268,345 @@ impl PrCommands {
 
                 Ok(())
             }
+
+            PrCommands::Commits { repo, id, limit } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let commits = client
+                    .list_pr_commits(&workspace, &repo_slug, id, Some(limit.clamp(1, 100)))
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&commits.values);
+                }
+
+                if commits.values.is_empty() {
+                    println!("No commits found");
+                    return Ok(());
+                }
+
+                let rows: Vec<CommitRow> = commits
+                    .values
+                    .iter()
+                    .map(|c| CommitRow {
+                        hash: c.hash.chars().take(12).collect(),
+                        date: c
+                            .date
+                            .map(|d| d.format("%Y-%m-%d %H:%M").to_string())
+                            .unwrap_or_else(|| "-".to_string()),
+                        message: first_line_truncated(c.message.as_deref().unwrap_or(""), 60),
+                    })
+                    .collect();
+
+                println!("{}", Table::new(rows));
+
+                if commits.next.is_some() {
+                    println!(
+                        "{} More commits available; use --limit to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
+                Ok(())
+            }
+
+            PrCommands::Statuses { repo, id } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let statuses = client.list_pr_statuses(&workspace, &repo_slug, id).await?;
+
+                if super::output_json() {
+                    return super::print_json(&statuses);
+                }
+
+                if statuses.is_empty() {
+                    println!("No build statuses found");
+                    return Ok(());
+                }
+
+                let rows: Vec<StatusRow> = statuses
+                    .iter()
+                    .map(|s| StatusRow {
+                        key: s.key.clone().unwrap_or_else(|| "-".to_string()),
+                        name: s.name.clone().unwrap_or_else(|| "-".to_string()),
+                        state: format_commit_status_state(s.state.as_deref().unwrap_or("-")),
+                        url: s.url.clone().unwrap_or_else(|| "-".to_string()),
+                    })
+                    .collect();
+
+                println!("{}", Table::new(rows));
+
+                Ok(())
+            }
+
+            PrCommands::Diffstat { repo, id, limit } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let limit = effective_limit(limit);
+                let client = BitbucketClient::from_stored().await?;
+
+                let diffstat = client
+                    .get_pr_diffstat(&workspace, &repo_slug, id, Some(limit))
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&diffstat.values);
+                }
+
+                if diffstat.values.is_empty() {
+                    println!("No changes found");
+                    return Ok(());
+                }
+
+                let rows: Vec<DiffstatRow> = diffstat
+                    .values
+                    .iter()
+                    .map(|e| {
+                        let file = e
+                            .new
+                            .as_ref()
+                            .and_then(|f| f.path.clone())
+                            .or_else(|| e.old.as_ref().and_then(|f| f.path.clone()))
+                            .unwrap_or_else(|| "-".to_string());
+
+                        DiffstatRow {
+                            status: e.status.clone().unwrap_or_else(|| "-".to_string()),
+                            file,
+                            added: e
+                                .lines_added
+                                .map(|n| n.to_string())
+                                .unwrap_or_else(|| "-".to_string()),
+                            removed: e
+                                .lines_removed
+                                .map(|n| n.to_string())
+                                .unwrap_or_else(|| "-".to_string()),
+                        }
+                    })
+                    .collect();
+
+                println!("{}", Table::new(rows));
+
+                let total_added: u64 = diffstat.values.iter().filter_map(|e| e.lines_added).sum();
+                let total_removed: u64 =
+                    diffstat.values.iter().filter_map(|e| e.lines_removed).sum();
+                println!(
+                    "{} files changed, {} insertions(+), {} deletions(-)",
+                    diffstat.values.len(),
+                    total_added.to_string().green(),
+                    total_removed.to_string().red()
+                );
+
+                if diffstat.next.is_some() {
+                    println!(
+                        "{} More changed files available; use --limit to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
+                Ok(())
+            }
+
+            PrCommands::Task { command } => command.run().await,
+
+            PrCommands::Activity { repo, id, limit } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let activity = client
+                    .list_pr_activity(&workspace, &repo_slug, id, Some(limit.clamp(1, 100)))
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&activity.values);
+                }
+
+                if activity.values.is_empty() {
+                    println!("No activity found");
+                    return Ok(());
+                }
+
+                for entry in &activity.values {
+                    println!("{}", format_activity_line(entry));
+                }
+
+                if activity.next.is_some() {
+                    println!(
+                        "{} More activity available; use --limit to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
+                Ok(())
+            }
+
+            PrCommands::Patch { repo, id } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let patch = client.get_pr_patch(&workspace, &repo_slug, id).await?;
+                println!("{}", patch);
+
+                Ok(())
+            }
+        }
+    }
+}
+
+impl TaskCommands {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            TaskCommands::List { repo, id } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let tasks = client.list_pr_tasks(&workspace, &repo_slug, id).await?;
+
+                if super::output_json() {
+                    return super::print_json(&tasks);
+                }
+
+                if tasks.is_empty() {
+                    println!("No tasks found");
+                    return Ok(());
+                }
+
+                let rows: Vec<TaskRow> = tasks
+                    .iter()
+                    .map(|t| TaskRow {
+                        id: t
+                            .id
+                            .map(|i| i.to_string())
+                            .unwrap_or_else(|| "-".to_string()),
+                        state: match t.state.as_deref() {
+                            Some("RESOLVED") => "RESOLVED".green().to_string(),
+                            Some("UNRESOLVED") => "UNRESOLVED".yellow().to_string(),
+                            Some(other) => other.to_string(),
+                            None => "-".to_string(),
+                        },
+                        content: first_line_truncated(
+                            t.content
+                                .as_ref()
+                                .and_then(|c| c.raw.as_deref())
+                                .unwrap_or(""),
+                            60,
+                        ),
+                    })
+                    .collect();
+
+                println!("{}", Table::new(rows));
+
+                Ok(())
+            }
+
+            TaskCommands::Add { repo, id, body } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let task = client
+                    .add_pr_task(&workspace, &repo_slug, id, &body)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&task);
+                }
+
+                match task.id {
+                    Some(task_id) => println!(
+                        "{} Added task #{} to pull request #{}",
+                        "✓".green(),
+                        task_id,
+                        id
+                    ),
+                    None => println!("{} Added task to pull request #{}", "✓".green(), id),
+                }
+
+                Ok(())
+            }
+
+            TaskCommands::Resolve { repo, id, task_id } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let task = client
+                    .update_pr_task(&workspace, &repo_slug, id, task_id, None, Some("RESOLVED"))
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&task);
+                }
+
+                println!(
+                    "{} Resolved task #{} on pull request #{}",
+                    "✓".green(),
+                    task_id,
+                    id
+                );
+
+                Ok(())
+            }
+
+            TaskCommands::Reopen { repo, id, task_id } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let task = client
+                    .update_pr_task(
+                        &workspace,
+                        &repo_slug,
+                        id,
+                        task_id,
+                        None,
+                        Some("UNRESOLVED"),
+                    )
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&task);
+                }
+
+                println!(
+                    "{} Reopened task #{} on pull request #{}",
+                    "✓".green(),
+                    task_id,
+                    id
+                );
+
+                Ok(())
+            }
+
+            TaskCommands::Delete {
+                repo,
+                id,
+                task_id,
+                yes,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                if !yes
+                    && !super::confirm_or_abort(format!("Delete task #{} on PR #{}?", task_id, id))?
+                {
+                    return Ok(());
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                client
+                    .delete_pr_task(&workspace, &repo_slug, id, task_id)
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
+                println!(
+                    "{} Deleted task #{} from pull request #{}",
+                    "✓".green(),
+                    task_id,
+                    id
+                );
+
+                Ok(())
+            }
         }
     }
 }
@@ -707,6 +1617,235 @@ fn format_state(state: &PullRequestState) -> String {
         PullRequestState::Merged => "MERGED".purple().to_string(),
         PullRequestState::Declined => "DECLINED".red().to_string(),
         PullRequestState::Superseded => "SUPERSEDED".yellow().to_string(),
+    }
+}
+
+fn format_commit_status_state(state: &str) -> String {
+    match state {
+        "SUCCESSFUL" => state.green().to_string(),
+        "FAILED" => state.red().to_string(),
+        "INPROGRESS" => state.yellow().to_string(),
+        "STOPPED" => state.dimmed().to_string(),
+        _ => state.to_string(),
+    }
+}
+
+/// Parse a comma-separated list of reviewer tokens into reviewer references,
+/// trimming whitespace and skipping empty segments. Each token is classified
+/// as an account ID / UUID or a username by [`reviewer_ref`].
+fn parse_reviewers(spec: &str) -> Vec<UserRef> {
+    spec.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(reviewer_ref)
+        .collect()
+}
+
+/// Classify a reviewer token and build the matching [`UserRef`].
+///
+/// Post-GDPR Bitbucket ignores `username` in request bodies, so a token that
+/// looks like an account ID or UUID — it starts with `{`, contains `:`, or
+/// matches the `8-4-4-4-12` hex-dash UUID shape — is placed in `uuid`.
+/// Everything else is treated as a `username`.
+fn reviewer_ref(token: &str) -> UserRef {
+    if looks_like_account_id(token) {
+        UserRef {
+            uuid: Some(token.to_string()),
+            username: None,
+        }
+    } else {
+        UserRef {
+            uuid: None,
+            username: Some(token.to_string()),
+        }
+    }
+}
+
+/// True when `token` looks like a Bitbucket account ID or UUID rather than a
+/// plain username.
+fn looks_like_account_id(token: &str) -> bool {
+    token.starts_with('{') || token.contains(':') || is_uuid(token)
+}
+
+/// True when `token` matches the canonical `8-4-4-4-12` hex-dash UUID shape.
+fn is_uuid(token: &str) -> bool {
+    const GROUPS: [usize; 5] = [8, 4, 4, 4, 12];
+
+    let mut parts = token.split('-');
+    for &len in &GROUPS {
+        match parts.next() {
+            Some(part) if part.len() == len && part.bytes().all(|b| b.is_ascii_hexdigit()) => {}
+            _ => return false,
+        }
+    }
+    parts.next().is_none()
+}
+
+/// True when a git remote URL points at `workspace/repo_slug`.
+///
+/// Matches case-insensitively and tolerates a trailing `.git` suffix or `/`,
+/// covering https (`https://host/ws/slug`), scp-style ssh
+/// (`git@host:ws/slug`), and `ssh://` URLs.
+fn remote_matches_repo(url: &str, workspace: &str, repo_slug: &str) -> bool {
+    let lowered = url.trim().to_lowercase();
+    let trimmed = lowered.trim_end_matches('/');
+    let trimmed = trimmed.strip_suffix(".git").unwrap_or(trimmed);
+
+    let expected = format!("{}/{}", workspace.to_lowercase(), repo_slug.to_lowercase());
+    trimmed.ends_with(&format!("/{}", expected)) || trimmed.ends_with(&format!(":{}", expected))
+}
+
+/// Fetch and check out the source branch of `pr` from `origin`.
+///
+/// Refuses to touch the working tree unless `origin` points at the PR's
+/// repository, and bails for PRs from forks (whose branches don't live on
+/// `origin`). After checkout, fast-forwards a stale local branch to the freshly
+/// fetched remote tip when possible.
+async fn checkout_pr_branch(pr: &PullRequest, workspace: &str, repo_slug: &str) -> Result<()> {
+    let branch = &pr.source.branch.name;
+
+    // Make sure `origin` actually points at the repo the PR
+    // belongs to before touching the working tree.
+    let output = std::process::Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .context("Failed to read the 'origin' remote URL")?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "Could not determine the 'origin' remote URL — is the current directory a git repository with an 'origin' remote?"
+        );
+    }
+
+    let origin_url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !remote_matches_repo(&origin_url, workspace, repo_slug) {
+        anyhow::bail!(
+            "The 'origin' remote ({}) does not point at {}/{}",
+            origin_url,
+            workspace,
+            repo_slug
+        );
+    }
+
+    // PRs from forks live in a different repository; fetching
+    // `origin` would not bring their branch down.
+    if let Some(source_repo) = &pr.source.repository {
+        let target = format!("{}/{}", workspace, repo_slug);
+        if !source_repo.full_name.eq_ignore_ascii_case(&target) {
+            anyhow::bail!(
+                "PR #{} comes from fork '{}' — add the fork as a remote and fetch manually",
+                pr.id,
+                source_repo.full_name
+            );
+        }
+    }
+
+    println!("Fetching and checking out branch {}...", branch.cyan());
+
+    // Fetch the branch
+    let status = std::process::Command::new("git")
+        .args(["fetch", "origin", branch])
+        .status()
+        .context("Failed to fetch branch")?;
+
+    if !status.success() {
+        anyhow::bail!("git fetch failed");
+    }
+
+    // Checkout the branch
+    let status = std::process::Command::new("git")
+        .args(["checkout", branch])
+        .status()
+        .context("Failed to checkout branch")?;
+
+    if status.success() {
+        // The local branch may be stale; fast-forward it to the
+        // freshly fetched remote tip when possible.
+        let ff_status = std::process::Command::new("git")
+            .args(["merge", "--ff-only", &format!("origin/{}", branch)])
+            .status()
+            .context("Failed to fast-forward branch")?;
+
+        if ff_status.success() {
+            println!("{} Checked out branch {}", "✓".green(), branch);
+        } else {
+            println!(
+                "{} Checked out branch {}, but it has diverged from origin/{} and could not be fast-forwarded; merge or rebase manually.",
+                "⚠".yellow(),
+                branch,
+                branch
+            );
+        }
+    } else {
+        // Try creating a tracking branch
+        let status = std::process::Command::new("git")
+            .args(["checkout", "-b", branch, &format!("origin/{}", branch)])
+            .status()
+            .context("Failed to create tracking branch")?;
+
+        if status.success() {
+            println!("{} Created and checked out branch {}", "✓".green(), branch);
+        } else {
+            anyhow::bail!("git checkout failed");
+        }
+    }
+
+    Ok(())
+}
+
+/// Return the first line of `text`, truncated to at most `max_chars` characters.
+fn first_line_truncated(text: &str, max_chars: usize) -> String {
+    text.lines()
+        .next()
+        .unwrap_or("")
+        .chars()
+        .take(max_chars)
+        .collect()
+}
+
+/// Extract a `YYYY-MM-DD HH:MM` timestamp from a JSON string field.
+fn activity_date(value: &serde_json::Value, pointer: &str) -> String {
+    value
+        .pointer(pointer)
+        .and_then(|v| v.as_str())
+        .map(|d| d.chars().take(16).collect::<String>().replace('T', " "))
+        .unwrap_or_else(|| "-".to_string())
+}
+
+/// Render one PR activity entry as a single typed line.
+fn format_activity_line(entry: &PrActivity) -> String {
+    fn str_at<'a>(value: &'a serde_json::Value, pointer: &'a str) -> Option<&'a str> {
+        value.pointer(pointer).and_then(|v| v.as_str())
+    }
+
+    if let Some(comment) = &entry.comment {
+        format!(
+            "[{}] comment: {} — {}",
+            activity_date(comment, "/created_on"),
+            str_at(comment, "/user/display_name").unwrap_or("unknown"),
+            first_line_truncated(str_at(comment, "/content/raw").unwrap_or(""), 60)
+        )
+    } else if let Some(approval) = &entry.approval {
+        format!(
+            "[{}] approval: approved by {}",
+            activity_date(approval, "/date"),
+            str_at(approval, "/user/display_name").unwrap_or("unknown")
+        )
+    } else if let Some(changes_requested) = &entry.changes_requested {
+        format!(
+            "[{}] changes-requested: by {}",
+            activity_date(changes_requested, "/date"),
+            str_at(changes_requested, "/user/display_name").unwrap_or("unknown")
+        )
+    } else if let Some(update) = &entry.update {
+        format!(
+            "[{}] update: {} by {}",
+            activity_date(update, "/date"),
+            str_at(update, "/state").unwrap_or("updated"),
+            str_at(update, "/author/display_name").unwrap_or("unknown")
+        )
+    } else {
+        "unrecognized activity entry".to_string()
     }
 }
 
@@ -724,8 +1863,11 @@ fn newest_comments_chronological(
 
 #[cfg(test)]
 mod tests {
-    use super::newest_comments_chronological;
-    use crate::models::{CommentContent, PullRequestComment, User};
+    use super::{
+        first_line_truncated, format_activity_line, format_commit_status_state,
+        newest_comments_chronological, parse_reviewers, remote_matches_repo, reviewer_ref,
+    };
+    use crate::models::{CommentContent, PrActivity, PullRequestComment, User};
     use chrono::{DateTime, Utc};
 
     fn ts(s: &str) -> DateTime<Utc> {
@@ -781,5 +1923,205 @@ mod tests {
 
         let times: Vec<DateTime<Utc>> = result.iter().map(|c| c.created_on).collect();
         assert_eq!(times, vec![t1, t2, t3]);
+    }
+
+    #[test]
+    fn remote_matches_repo_accepts_https_urls() {
+        assert!(remote_matches_repo(
+            "https://bitbucket.org/acme/my-repo",
+            "acme",
+            "my-repo"
+        ));
+        assert!(remote_matches_repo(
+            "https://user@bitbucket.org/acme/my-repo.git",
+            "acme",
+            "my-repo"
+        ));
+    }
+
+    #[test]
+    fn remote_matches_repo_accepts_ssh_urls() {
+        assert!(remote_matches_repo(
+            "git@bitbucket.org:acme/my-repo.git",
+            "acme",
+            "my-repo"
+        ));
+        assert!(remote_matches_repo(
+            "ssh://git@bitbucket.org/acme/my-repo.git",
+            "acme",
+            "my-repo"
+        ));
+    }
+
+    #[test]
+    fn remote_matches_repo_tolerates_case_and_trailing_slash() {
+        assert!(remote_matches_repo(
+            "https://bitbucket.org/Acme/My-Repo.git/",
+            "acme",
+            "my-repo"
+        ));
+        assert!(remote_matches_repo(
+            "git@bitbucket.org:ACME/MY-REPO",
+            "Acme",
+            "My-Repo"
+        ));
+    }
+
+    #[test]
+    fn remote_matches_repo_rejects_other_repos() {
+        assert!(!remote_matches_repo(
+            "https://bitbucket.org/acme/other-repo.git",
+            "acme",
+            "my-repo"
+        ));
+        assert!(!remote_matches_repo(
+            "git@bitbucket.org:someone-else/my-repo.git",
+            "acme",
+            "my-repo"
+        ));
+        // A workspace that merely ends with the expected name must not match.
+        assert!(!remote_matches_repo(
+            "https://bitbucket.org/other-acme/my-repo",
+            "acme",
+            "my-repo"
+        ));
+        assert!(!remote_matches_repo("", "acme", "my-repo"));
+    }
+
+    #[test]
+    fn parse_reviewers_splits_trims_and_skips_empty_segments() {
+        let reviewers = parse_reviewers(" alice , bob,,charlie ");
+
+        let usernames: Vec<Option<String>> = reviewers.iter().map(|r| r.username.clone()).collect();
+        assert_eq!(
+            usernames,
+            vec![
+                Some("alice".to_string()),
+                Some("bob".to_string()),
+                Some("charlie".to_string())
+            ]
+        );
+        assert!(reviewers.iter().all(|r| r.uuid.is_none()));
+    }
+
+    #[test]
+    fn reviewer_ref_classifies_uuid_and_username_tokens() {
+        // Brace-wrapped UUID -> uuid
+        let braced = reviewer_ref("{4d9e8f2a-1234-5678-9abc-def012345678}");
+        assert_eq!(
+            braced.uuid.as_deref(),
+            Some("{4d9e8f2a-1234-5678-9abc-def012345678}")
+        );
+        assert!(braced.username.is_none());
+
+        // Bare UUID (8-4-4-4-12 hex-dash) -> uuid
+        let uuid = reviewer_ref("4d9e8f2a-1234-5678-9abc-def012345678");
+        assert_eq!(
+            uuid.uuid.as_deref(),
+            Some("4d9e8f2a-1234-5678-9abc-def012345678")
+        );
+        assert!(uuid.username.is_none());
+
+        // Account ID (contains a colon) -> uuid
+        let account = reviewer_ref("557058:e5f8d5c1-0000-1111-2222-333344445555");
+        assert_eq!(
+            account.uuid.as_deref(),
+            Some("557058:e5f8d5c1-0000-1111-2222-333344445555")
+        );
+        assert!(account.username.is_none());
+
+        // Plain username -> username
+        let username = reviewer_ref("alice");
+        assert_eq!(username.username.as_deref(), Some("alice"));
+        assert!(username.uuid.is_none());
+
+        // A dashed but non-hex/non-UUID-shaped token stays a username.
+        let dashed = reviewer_ref("my-cool-user");
+        assert_eq!(dashed.username.as_deref(), Some("my-cool-user"));
+        assert!(dashed.uuid.is_none());
+    }
+
+    #[test]
+    fn format_commit_status_state_preserves_state_text() {
+        for state in ["SUCCESSFUL", "FAILED", "INPROGRESS", "STOPPED"] {
+            assert!(
+                format_commit_status_state(state).contains(state),
+                "state text {state} should be preserved",
+            );
+        }
+    }
+
+    #[test]
+    fn first_line_truncated_keeps_only_the_first_line() {
+        assert_eq!(first_line_truncated("one\ntwo", 60), "one");
+        assert_eq!(first_line_truncated("abcdef", 3), "abc");
+        assert_eq!(first_line_truncated("", 10), "");
+    }
+
+    fn empty_activity() -> PrActivity {
+        PrActivity {
+            update: None,
+            approval: None,
+            comment: None,
+            changes_requested: None,
+        }
+    }
+
+    #[test]
+    fn format_activity_line_renders_each_entry_type() {
+        let update = PrActivity {
+            update: Some(serde_json::json!({
+                "date": "2024-05-01T10:20:30+00:00",
+                "state": "OPEN",
+                "author": { "display_name": "Alice" }
+            })),
+            ..empty_activity()
+        };
+        assert_eq!(
+            format_activity_line(&update),
+            "[2024-05-01 10:20] update: OPEN by Alice"
+        );
+
+        let approval = PrActivity {
+            approval: Some(serde_json::json!({
+                "date": "2024-05-02T11:00:00+00:00",
+                "user": { "display_name": "Bob" }
+            })),
+            ..empty_activity()
+        };
+        assert_eq!(
+            format_activity_line(&approval),
+            "[2024-05-02 11:00] approval: approved by Bob"
+        );
+
+        let comment = PrActivity {
+            comment: Some(serde_json::json!({
+                "created_on": "2024-05-03T09:15:00+00:00",
+                "user": { "display_name": "Carol" },
+                "content": { "raw": "Looks good\nSecond line ignored" }
+            })),
+            ..empty_activity()
+        };
+        assert_eq!(
+            format_activity_line(&comment),
+            "[2024-05-03 09:15] comment: Carol — Looks good"
+        );
+
+        let changes_requested = PrActivity {
+            changes_requested: Some(serde_json::json!({
+                "date": "2024-05-04T08:00:00+00:00",
+                "user": { "display_name": "Dave" }
+            })),
+            ..empty_activity()
+        };
+        assert_eq!(
+            format_activity_line(&changes_requested),
+            "[2024-05-04 08:00] changes-requested: by Dave"
+        );
+
+        assert_eq!(
+            format_activity_line(&empty_activity()),
+            "unrecognized activity entry"
+        );
     }
 }

--- a/src/cli/repo.rs
+++ b/src/cli/repo.rs
@@ -8,6 +8,7 @@ use tabled::{Table, Tabled};
 
 use super::parse_repo;
 use crate::api::{BitbucketClient, download_url};
+use crate::cli::pagination::{effective_limit, format_size};
 use crate::models::{CreateRepositoryRequest, UpdateRepositoryRequest};
 
 #[derive(Subcommand)]
@@ -17,9 +18,25 @@ pub enum RepoCommands {
         /// Workspace slug (defaults to --workspace or the configured default workspace)
         workspace: Option<String>,
 
-        /// Number of results per page
+        /// Number of results per page (max 100)
         #[arg(short, long, default_value = "25")]
         limit: u32,
+
+        /// Filter by the authenticated user's role on the repository
+        #[arg(long, value_parser = ["member", "contributor", "admin", "owner"])]
+        role: Option<String>,
+
+        /// Filter with a Bitbucket query (BBQL) expression, e.g. 'language="rust"'
+        #[arg(short, long)]
+        query: Option<String>,
+
+        /// Sort by a field, e.g. 'name' or '-updated_on' for descending
+        #[arg(long)]
+        sort: Option<String>,
+
+        /// Page number to fetch
+        #[arg(long)]
+        page: Option<u32>,
     },
 
     /// View repository details
@@ -67,6 +84,26 @@ pub enum RepoCommands {
         /// Fork policy: allow_forks, no_public_forks, no_forks (default: allow_forks when --public, no_public_forks otherwise)
         #[arg(long)]
         fork_policy: Option<String>,
+
+        /// Primary language
+        #[arg(short, long)]
+        language: Option<String>,
+
+        /// Enable or disable the issue tracker (default: enabled)
+        #[arg(long, value_name = "true|false")]
+        issues: Option<bool>,
+
+        /// Enable or disable the wiki (default: disabled)
+        #[arg(long, value_name = "true|false")]
+        wiki: Option<bool>,
+
+        /// Website URL to show on the repository
+        #[arg(long)]
+        website: Option<String>,
+
+        /// Main branch name
+        #[arg(long)]
+        main_branch: Option<String>,
     },
 
     /// Update repository settings
@@ -106,6 +143,10 @@ pub enum RepoCommands {
         #[arg(long, value_name = "true|false")]
         wiki: Option<bool>,
 
+        /// Website URL to show on the repository
+        #[arg(long)]
+        website: Option<String>,
+
         /// Main branch name
         #[arg(long)]
         main_branch: Option<String>,
@@ -144,10 +185,102 @@ pub enum RepoCommands {
         yes: bool,
     },
 
+    /// List users watching a repository
+    Watchers {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Maximum number of watchers to list (max 100)
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+    },
+
+    /// List forks of a repository
+    Forks {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Maximum number of forks to list (max 100)
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+    },
+
     /// Manage repository downloads (uploaded file artifacts)
     Download {
         #[command(subcommand)]
         command: DownloadCommands,
+    },
+
+    /// Manage repository branches
+    Branch {
+        #[command(subcommand)]
+        command: super::branch::BranchCommands,
+    },
+
+    /// Manage repository tags
+    Tag {
+        #[command(subcommand)]
+        command: super::tag::TagCommands,
+    },
+
+    /// Work with repository commits
+    Commit {
+        #[command(subcommand)]
+        command: super::commit::CommitCommands,
+    },
+
+    /// Browse repository files and file contents
+    File {
+        #[command(subcommand)]
+        command: super::file::FileCommands,
+    },
+
+    /// Manage repository webhooks
+    Webhook {
+        #[command(subcommand)]
+        command: super::webhook::WebhookCommands,
+    },
+
+    /// Manage branch restrictions (branch permissions)
+    BranchRestriction {
+        #[command(subcommand)]
+        command: super::branch_restriction::BranchRestrictionCommands,
+    },
+
+    /// Manage default reviewers
+    Reviewer {
+        #[command(subcommand)]
+        command: super::reviewer::ReviewerCommands,
+    },
+
+    /// Inspect repository user and group permissions
+    Permission {
+        #[command(subcommand)]
+        command: super::permission::PermissionCommands,
+    },
+
+    /// Manage repository deploy keys
+    DeployKey {
+        #[command(subcommand)]
+        command: super::deploy::DeployKeyCommands,
+    },
+
+    /// Manage deployment environments
+    Environment {
+        #[command(subcommand)]
+        command: super::deploy::EnvironmentCommands,
+    },
+
+    /// View repository deployments
+    Deployment {
+        #[command(subcommand)]
+        command: super::deploy::DeploymentCommands,
+    },
+
+    /// Manage the repository branching model
+    BranchingModel {
+        #[command(subcommand)]
+        command: super::branching_model::BranchingModelCommands,
     },
 }
 
@@ -167,6 +300,19 @@ pub enum DownloadCommands {
     List {
         /// Repository in format workspace/repo-slug
         repo: String,
+    },
+
+    /// Download an artifact from the repository's downloads area
+    Get {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Name of the artifact to download
+        name: String,
+
+        /// Output path (defaults to the artifact name in the current directory)
+        #[arg(short, long)]
+        output: Option<PathBuf>,
     },
 
     /// Delete an artifact from the repository's downloads area
@@ -195,53 +341,83 @@ struct RepoRow {
     updated: String,
 }
 
+#[derive(Tabled)]
+struct WatcherRow {
+    #[tabled(rename = "NAME")]
+    name: String,
+    #[tabled(rename = "USERNAME")]
+    username: String,
+}
+
+/// Map repositories into table rows shared by `repo list` and `repo forks`.
+fn repo_rows(repos: &[crate::models::Repository]) -> Vec<RepoRow> {
+    repos
+        .iter()
+        .map(|r| RepoRow {
+            name: r.full_name.clone(),
+            description: r
+                .description
+                .clone()
+                .unwrap_or_default()
+                .chars()
+                .take(40)
+                .collect::<String>(),
+            private: if r.is_private.unwrap_or(false) {
+                "Yes"
+            } else {
+                "No"
+            }
+            .to_string(),
+            updated: r
+                .updated_on
+                .map(|d| d.format("%Y-%m-%d").to_string())
+                .unwrap_or_default(),
+        })
+        .collect()
+}
+
 impl RepoCommands {
     pub async fn run(self) -> Result<()> {
         match self {
-            RepoCommands::List { workspace, limit } => {
+            RepoCommands::List {
+                workspace,
+                limit,
+                role,
+                query,
+                sort,
+                page,
+            } => {
                 let workspace = super::resolve_workspace(workspace)?;
+                let limit = effective_limit(limit);
                 let client = BitbucketClient::from_stored().await?;
                 let repos = client
-                    .list_repositories(&workspace, None, Some(limit))
+                    .list_repositories_filtered(
+                        &workspace,
+                        role.as_deref(),
+                        query.as_deref(),
+                        sort.as_deref(),
+                        page,
+                        Some(limit),
+                    )
                     .await?;
+
+                if super::output_json() {
+                    return super::print_json(&repos.values);
+                }
 
                 if repos.values.is_empty() {
                     println!("No repositories found in workspace '{}'", workspace);
                     return Ok(());
                 }
 
-                let rows: Vec<RepoRow> = repos
-                    .values
-                    .iter()
-                    .map(|r| RepoRow {
-                        name: r.full_name.clone(),
-                        description: r
-                            .description
-                            .clone()
-                            .unwrap_or_default()
-                            .chars()
-                            .take(40)
-                            .collect::<String>(),
-                        private: if r.is_private.unwrap_or(false) {
-                            "Yes"
-                        } else {
-                            "No"
-                        }
-                        .to_string(),
-                        updated: r
-                            .updated_on
-                            .map(|d| d.format("%Y-%m-%d").to_string())
-                            .unwrap_or_default(),
-                    })
-                    .collect();
-
-                let table = Table::new(rows).to_string();
+                let table = Table::new(repo_rows(&repos.values)).to_string();
                 println!("{}", table);
 
                 if repos.next.is_some() {
                     println!(
-                        "\n{} More repositories available. Use --limit to see more.",
-                        "ℹ".blue()
+                        "\n{} More repositories available. Use --page {} to see the next page.",
+                        "ℹ".blue(),
+                        page.unwrap_or(1) + 1
                     );
                 }
 
@@ -262,6 +438,10 @@ impl RepoCommands {
                         }
                     }
                     anyhow::bail!("Could not find repository URL");
+                }
+
+                if super::output_json() {
+                    return super::print_json(&repository);
                 }
 
                 println!("{}", repository.full_name.bold());
@@ -365,6 +545,11 @@ impl RepoCommands {
                 public,
                 project,
                 fork_policy,
+                language,
+                issues,
+                wiki,
+                website,
+                main_branch,
             } => {
                 let (workspace, name) = super::resolve_create_target(workspace, name)?;
 
@@ -372,27 +557,26 @@ impl RepoCommands {
 
                 let slug = name.to_lowercase().replace(' ', "-");
 
-                let resolved_fork_policy = fork_policy.unwrap_or_else(|| {
-                    if public {
-                        "allow_forks".to_string()
-                    } else {
-                        "no_public_forks".to_string()
-                    }
-                });
-
-                let request = CreateRepositoryRequest {
-                    scm: "git".to_string(),
-                    name: Some(name.clone()),
+                let request = build_create_request(CreateFlags {
+                    name,
                     description,
-                    is_private: Some(!public),
-                    project: project.map(|key| crate::models::ProjectKey { key }),
-                    fork_policy: Some(resolved_fork_policy),
-                    ..Default::default()
-                };
+                    public,
+                    project,
+                    fork_policy,
+                    language,
+                    issues,
+                    wiki,
+                    website,
+                    main_branch,
+                });
 
                 let repository = client
                     .create_repository(&workspace, &slug, &request)
                     .await?;
+
+                if super::output_json() {
+                    return super::print_json(&repository);
+                }
 
                 println!(
                     "{} Created repository {}",
@@ -419,6 +603,7 @@ impl RepoCommands {
                 fork_policy,
                 issues,
                 wiki,
+                website,
                 main_branch,
             } => {
                 let (workspace, repo_slug) = parse_repo(&repo)?;
@@ -432,6 +617,7 @@ impl RepoCommands {
                     fork_policy,
                     issues,
                     wiki,
+                    website,
                     main_branch,
                 });
 
@@ -445,6 +631,10 @@ impl RepoCommands {
                 let updated = client
                     .update_repository(&workspace, &repo_slug, &request)
                     .await?;
+
+                if super::output_json() {
+                    return super::print_json(&updated);
+                }
 
                 println!(
                     "{} Updated repository {}",
@@ -481,6 +671,10 @@ impl RepoCommands {
                     .update_repository(&workspace, &repo_slug, &request)
                     .await?;
 
+                if super::output_json() {
+                    return super::print_json(&updated);
+                }
+
                 let project_label = updated
                     .project
                     .as_ref()
@@ -514,6 +708,10 @@ impl RepoCommands {
                     )
                     .await?;
 
+                if super::output_json() {
+                    return super::print_json(&forked);
+                }
+
                 println!("{} Forked to {}", "✓".green(), forked.full_name.cyan());
 
                 Ok(())
@@ -534,12 +732,95 @@ impl RepoCommands {
                 let client = BitbucketClient::from_stored().await?;
                 client.delete_repository(&workspace, &repo_slug).await?;
 
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
                 println!("{} Deleted repository {}", "✓".green(), repo);
 
                 Ok(())
             }
 
+            RepoCommands::Watchers { repo, limit } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let limit = effective_limit(limit);
+                let client = BitbucketClient::from_stored().await?;
+                let watchers = client
+                    .list_watchers(&workspace, &repo_slug, Some(limit))
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&watchers.values);
+                }
+
+                if watchers.values.is_empty() {
+                    println!("No watchers found for {}", repo);
+                    return Ok(());
+                }
+
+                let rows: Vec<WatcherRow> = watchers
+                    .values
+                    .iter()
+                    .map(|u| WatcherRow {
+                        name: u.display_name.clone(),
+                        username: u.username.clone().unwrap_or_else(|| "-".to_string()),
+                    })
+                    .collect();
+
+                println!("{}", Table::new(rows));
+
+                if watchers.next.is_some() {
+                    println!(
+                        "\n{} More watchers available. Use --limit to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
+                Ok(())
+            }
+
+            RepoCommands::Forks { repo, limit } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let limit = effective_limit(limit);
+                let client = BitbucketClient::from_stored().await?;
+                let forks = client
+                    .list_forks(&workspace, &repo_slug, Some(limit))
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&forks.values);
+                }
+
+                if forks.values.is_empty() {
+                    println!("No forks found for {}", repo);
+                    return Ok(());
+                }
+
+                println!("{}", Table::new(repo_rows(&forks.values)));
+
+                if forks.next.is_some() {
+                    println!(
+                        "\n{} More forks available. Use --limit to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
+                Ok(())
+            }
+
             RepoCommands::Download { command } => command.run().await,
+            RepoCommands::Branch { command } => command.run().await,
+            RepoCommands::Tag { command } => command.run().await,
+            RepoCommands::Commit { command } => command.run().await,
+            RepoCommands::File { command } => command.run().await,
+            RepoCommands::Webhook { command } => command.run().await,
+            RepoCommands::BranchRestriction { command } => command.run().await,
+            RepoCommands::Reviewer { command } => command.run().await,
+            RepoCommands::Permission { command } => command.run().await,
+            RepoCommands::DeployKey { command } => command.run().await,
+            RepoCommands::Environment { command } => command.run().await,
+            RepoCommands::Deployment { command } => command.run().await,
+            RepoCommands::BranchingModel { command } => command.run().await,
         }
     }
 }
@@ -584,6 +865,10 @@ impl DownloadCommands {
                     .upload_downloads(&workspace, &repo_slug, &uploads)
                     .await?;
 
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
                 for (name, _) in &uploads {
                     println!(
                         "{} Uploaded {}",
@@ -599,6 +884,10 @@ impl DownloadCommands {
                 let (workspace, repo_slug) = parse_repo(&repo)?;
                 let client = BitbucketClient::from_stored().await?;
                 let downloads = client.list_downloads(&workspace, &repo_slug).await?;
+
+                if super::output_json() {
+                    return super::print_json(&downloads);
+                }
 
                 if downloads.is_empty() {
                     println!("No downloads found in {}", repo);
@@ -618,6 +907,43 @@ impl DownloadCommands {
                     .collect();
 
                 println!("{}", Table::new(rows));
+
+                Ok(())
+            }
+
+            DownloadCommands::Get { repo, name, output } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let bytes = client
+                    .get_download(&workspace, &repo_slug, &name)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "Failed to download '{}' from {}/{}",
+                            name, workspace, repo_slug
+                        )
+                    })?;
+
+                let output = output.unwrap_or_else(|| PathBuf::from(&name));
+                std::fs::write(&output, &bytes)
+                    .with_context(|| format!("Failed to write '{}'", output.display()))?;
+
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({
+                        "ok": true,
+                        "path": output.display().to_string(),
+                        "bytes": bytes.len(),
+                    }));
+                }
+
+                println!(
+                    "{} Downloaded {} to {} ({} bytes)",
+                    "✓".green(),
+                    name.cyan(),
+                    output.display(),
+                    bytes.len()
+                );
 
                 Ok(())
             }
@@ -642,11 +968,65 @@ impl DownloadCommands {
                         )
                     })?;
 
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
                 println!("{} Deleted download {}", "✓".green(), name);
 
                 Ok(())
             }
         }
+    }
+}
+
+/// The `repo create` command-line flags, grouped for translation into a
+/// `CreateRepositoryRequest`.
+#[derive(Default)]
+struct CreateFlags {
+    name: String,
+    description: Option<String>,
+    public: bool,
+    project: Option<String>,
+    fork_policy: Option<String>,
+    language: Option<String>,
+    issues: Option<bool>,
+    wiki: Option<bool>,
+    website: Option<String>,
+    main_branch: Option<String>,
+}
+
+/// Build the creation request for `repo create` from its command-line flags.
+///
+/// An explicit --fork-policy wins; otherwise public repositories default to
+/// `allow_forks` and private ones to `no_public_forks`. --issues and --wiki
+/// override the request defaults (issues on, wiki off).
+fn build_create_request(flags: CreateFlags) -> CreateRepositoryRequest {
+    let defaults = CreateRepositoryRequest::default();
+
+    let fork_policy = flags.fork_policy.unwrap_or_else(|| {
+        if flags.public {
+            "allow_forks".to_string()
+        } else {
+            "no_public_forks".to_string()
+        }
+    });
+
+    CreateRepositoryRequest {
+        scm: "git".to_string(),
+        name: Some(flags.name),
+        description: flags.description,
+        is_private: Some(!flags.public),
+        project: flags.project.map(|key| crate::models::ProjectKey { key }),
+        fork_policy: Some(fork_policy),
+        language: flags.language,
+        has_issues: flags.issues.or(defaults.has_issues),
+        has_wiki: flags.wiki.or(defaults.has_wiki),
+        website: flags.website,
+        mainbranch: flags.main_branch.map(|name| crate::models::Branch {
+            name,
+            branch_type: None,
+        }),
     }
 }
 
@@ -662,6 +1042,7 @@ struct UpdateFlags {
     fork_policy: Option<String>,
     issues: Option<bool>,
     wiki: Option<bool>,
+    website: Option<String>,
     main_branch: Option<String>,
 }
 
@@ -681,6 +1062,7 @@ fn build_update_request(flags: UpdateFlags) -> UpdateRepositoryRequest {
         fork_policy: flags.fork_policy,
         has_issues: flags.issues,
         has_wiki: flags.wiki,
+        website: flags.website,
         project: None,
         mainbranch: flags.main_branch.map(|name| crate::models::Branch {
             name,
@@ -689,21 +1071,7 @@ fn build_update_request(flags: UpdateFlags) -> UpdateRepositoryRequest {
     }
 }
 
-/// Ask the user to confirm a destructive action; on decline, print "Aborted"
-/// and return Ok(false).
-fn confirm_or_abort(prompt: String) -> Result<bool> {
-    use dialoguer::Confirm;
-    let confirmed = Confirm::new()
-        .with_prompt(prompt)
-        .default(false)
-        .interact()?;
-
-    if !confirmed {
-        println!("Aborted");
-    }
-
-    Ok(confirmed)
-}
+use super::confirm_or_abort;
 
 /// Extract the file name (final path component) from a path, for use as the
 /// uploaded artifact name.
@@ -714,40 +1082,9 @@ fn upload_name_for(path: &Path) -> Result<String> {
         .with_context(|| format!("Could not determine a file name for '{}'", path.display()))
 }
 
-/// Format a byte count into a short human-readable string.
-fn format_size(bytes: u64) -> String {
-    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
-    let mut size = bytes as f64;
-    let mut unit = 0;
-    while size >= 1024.0 && unit < UNITS.len() - 1 {
-        size /= 1024.0;
-        unit += 1;
-    }
-    if unit == 0 {
-        format!("{} {}", bytes, UNITS[unit])
-    } else {
-        format!("{:.1} {}", size, UNITS[unit])
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn format_size_uses_bytes_below_1k() {
-        assert_eq!(format_size(0), "0 B");
-        assert_eq!(format_size(512), "512 B");
-        assert_eq!(format_size(1023), "1023 B");
-    }
-
-    #[test]
-    fn format_size_scales_to_larger_units() {
-        assert_eq!(format_size(1024), "1.0 KB");
-        assert_eq!(format_size(1536), "1.5 KB");
-        assert_eq!(format_size(1024 * 1024), "1.0 MB");
-        assert_eq!(format_size(5 * 1024 * 1024 * 1024), "5.0 GB");
-    }
 
     #[test]
     fn upload_name_takes_final_component() {
@@ -786,6 +1123,84 @@ mod tests {
         });
         let branch = request.mainbranch.expect("mainbranch should be set");
         assert_eq!(branch.name, "develop");
+        assert_eq!(branch.branch_type, None);
+    }
+
+    #[test]
+    fn build_update_request_maps_website() {
+        let request = build_update_request(UpdateFlags {
+            website: Some("https://example.com".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(request.website.as_deref(), Some("https://example.com"));
+    }
+
+    #[test]
+    fn build_create_request_keeps_defaults_without_flags() {
+        let request = build_create_request(CreateFlags {
+            name: "widgets".to_string(),
+            ..Default::default()
+        });
+
+        assert_eq!(request.name.as_deref(), Some("widgets"));
+        assert_eq!(request.is_private, Some(true));
+        assert_eq!(request.fork_policy.as_deref(), Some("no_public_forks"));
+        // Defaults from CreateRepositoryRequest::default(): issues on, wiki off.
+        assert_eq!(request.has_issues, Some(true));
+        assert_eq!(request.has_wiki, Some(false));
+        assert_eq!(request.website, None);
+        assert!(request.mainbranch.is_none());
+    }
+
+    #[test]
+    fn build_create_request_flags_override_issue_and_wiki_defaults() {
+        let request = build_create_request(CreateFlags {
+            name: "widgets".to_string(),
+            issues: Some(false),
+            wiki: Some(true),
+            ..Default::default()
+        });
+
+        assert_eq!(request.has_issues, Some(false));
+        assert_eq!(request.has_wiki, Some(true));
+    }
+
+    #[test]
+    fn build_create_request_public_defaults_to_allow_forks() {
+        let request = build_create_request(CreateFlags {
+            name: "widgets".to_string(),
+            public: true,
+            ..Default::default()
+        });
+
+        assert_eq!(request.is_private, Some(false));
+        assert_eq!(request.fork_policy.as_deref(), Some("allow_forks"));
+    }
+
+    #[test]
+    fn build_create_request_explicit_fork_policy_wins() {
+        let request = build_create_request(CreateFlags {
+            name: "widgets".to_string(),
+            public: true,
+            fork_policy: Some("no_forks".to_string()),
+            ..Default::default()
+        });
+
+        assert_eq!(request.fork_policy.as_deref(), Some("no_forks"));
+    }
+
+    #[test]
+    fn build_create_request_maps_website_and_main_branch() {
+        let request = build_create_request(CreateFlags {
+            name: "widgets".to_string(),
+            website: Some("https://example.com".to_string()),
+            main_branch: Some("trunk".to_string()),
+            ..Default::default()
+        });
+
+        assert_eq!(request.website.as_deref(), Some("https://example.com"));
+        let branch = request.mainbranch.expect("mainbranch should be set");
+        assert_eq!(branch.name, "trunk");
         assert_eq!(branch.branch_type, None);
     }
 }

--- a/src/cli/reviewer.rs
+++ b/src/cli/reviewer.rs
@@ -1,0 +1,149 @@
+use anyhow::Result;
+use clap::Subcommand;
+use colored::Colorize;
+use tabled::{Table, Tabled};
+
+use super::{confirm_or_abort, output_json, parse_repo, print_json};
+use crate::api::BitbucketClient;
+
+#[derive(Subcommand)]
+pub enum ReviewerCommands {
+    /// List a repository's default reviewers
+    List {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Number of results per page (max 100)
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+    },
+
+    /// Add a user to the default reviewers
+    Add {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Username, account ID, or brace-wrapped UUID of the user
+        username: String,
+    },
+
+    /// Remove a user from the default reviewers
+    Remove {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Username, account ID, or brace-wrapped UUID of the user
+        username: String,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+}
+
+#[derive(Tabled)]
+struct ReviewerRow {
+    #[tabled(rename = "NAME")]
+    name: String,
+    #[tabled(rename = "USERNAME")]
+    username: String,
+    #[tabled(rename = "UUID")]
+    uuid: String,
+}
+
+impl ReviewerCommands {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            ReviewerCommands::List { repo, limit } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let reviewers = client
+                    .list_default_reviewers(&workspace, &repo_slug, Some(limit.clamp(1, 100)))
+                    .await?;
+
+                if output_json() {
+                    return print_json(&reviewers.values);
+                }
+
+                if reviewers.values.is_empty() {
+                    println!("No default reviewers found in {}", repo);
+                    return Ok(());
+                }
+
+                let rows: Vec<ReviewerRow> = reviewers
+                    .values
+                    .iter()
+                    .map(|u| ReviewerRow {
+                        name: u.display_name.clone(),
+                        username: u.username.clone().unwrap_or_else(|| "-".to_string()),
+                        uuid: u.uuid.clone(),
+                    })
+                    .collect();
+
+                println!("{}", Table::new(rows));
+
+                if reviewers.next.is_some() {
+                    println!(
+                        "\n{} More default reviewers available. Use --limit to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
+                Ok(())
+            }
+
+            ReviewerCommands::Add { repo, username } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let user = client
+                    .add_default_reviewer(&workspace, &repo_slug, &username)
+                    .await?;
+
+                if output_json() {
+                    return print_json(&user);
+                }
+
+                println!(
+                    "{} Added {} as a default reviewer on {}",
+                    "✓".green(),
+                    user.display_name.cyan(),
+                    repo
+                );
+
+                Ok(())
+            }
+
+            ReviewerCommands::Remove {
+                repo,
+                username,
+                yes,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                if !yes
+                    && !confirm_or_abort(format!(
+                        "Remove {} from the default reviewers of {}?",
+                        username.red(),
+                        repo
+                    ))?
+                {
+                    return Ok(());
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                client
+                    .remove_default_reviewer(&workspace, &repo_slug, &username)
+                    .await?;
+
+                if output_json() {
+                    return print_json(&serde_json::json!({ "ok": true }));
+                }
+
+                println!("{} Removed default reviewer {}", "✓".green(), username);
+
+                Ok(())
+            }
+        }
+    }
+}

--- a/src/cli/tag.rs
+++ b/src/cli/tag.rs
@@ -1,0 +1,256 @@
+use anyhow::Result;
+use clap::Subcommand;
+use colored::Colorize;
+use tabled::{Table, Tabled};
+
+use super::commit::{author_label, first_line_truncated, short_hash};
+use super::{confirm_or_abort, output_json, parse_repo, print_json};
+use crate::api::BitbucketClient;
+use crate::cli::pagination::effective_limit;
+use crate::models::TagDetail;
+
+/// Width of the truncated commit-message column in list tables.
+const MSG_WIDTH: usize = 50;
+
+#[derive(Subcommand)]
+pub enum TagCommands {
+    /// List tags in a repository
+    List {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Filter expression, e.g. 'name ~ "v1"'
+        #[arg(short = 'q', long)]
+        query: Option<String>,
+
+        /// Sort field, prefix with '-' for descending, e.g. -target.date
+        #[arg(long)]
+        sort: Option<String>,
+
+        /// Number of results per page (max 100)
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+
+        /// Page number to fetch
+        #[arg(long)]
+        page: Option<u32>,
+    },
+
+    /// Create a tag
+    Create {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Name of the tag to create
+        name: String,
+
+        /// Commit hash the tag points at
+        #[arg(long, value_name = "HASH")]
+        from: String,
+
+        /// Annotation message (creates an annotated tag)
+        #[arg(short = 'm', long)]
+        message: Option<String>,
+    },
+
+    /// View a single tag
+    View {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Tag name
+        name: String,
+    },
+
+    /// Delete a tag
+    Delete {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Tag name
+        name: String,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+}
+
+#[derive(Tabled)]
+struct TagRow {
+    #[tabled(rename = "NAME")]
+    name: String,
+    #[tabled(rename = "COMMIT")]
+    commit: String,
+    #[tabled(rename = "DATE")]
+    date: String,
+    #[tabled(rename = "MESSAGE")]
+    message: String,
+}
+
+impl From<&TagDetail> for TagRow {
+    fn from(tag: &TagDetail) -> Self {
+        let target = tag.target.as_ref();
+        TagRow {
+            name: tag.name.clone(),
+            commit: target.map(|t| short_hash(&t.hash)).unwrap_or_default(),
+            // Annotated tags carry their own date; fall back to the target
+            // commit's date for lightweight tags.
+            date: tag
+                .date
+                .or_else(|| target.and_then(|t| t.date))
+                .map(|d| d.format("%Y-%m-%d").to_string())
+                .unwrap_or_default(),
+            message: tag
+                .message
+                .as_deref()
+                .map(|m| first_line_truncated(m, MSG_WIDTH))
+                .unwrap_or_default(),
+        }
+    }
+}
+
+impl TagCommands {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            TagCommands::List {
+                repo,
+                query,
+                sort,
+                limit,
+                page,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let tags = client
+                    .list_tags_filtered(
+                        &workspace,
+                        &repo_slug,
+                        query.as_deref(),
+                        sort.as_deref(),
+                        page,
+                        Some(effective_limit(limit)),
+                    )
+                    .await?;
+
+                if output_json() {
+                    return print_json(&tags.values);
+                }
+
+                if tags.values.is_empty() {
+                    println!("No tags found in {}", repo);
+                    return Ok(());
+                }
+
+                let rows: Vec<TagRow> = tags.values.iter().map(TagRow::from).collect();
+                println!("{}", Table::new(rows));
+
+                if tags.next.is_some() {
+                    println!(
+                        "\n{} More tags available. Use --limit or --page to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
+                Ok(())
+            }
+
+            TagCommands::Create {
+                repo,
+                name,
+                from,
+                message,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let tag = client
+                    .create_tag(&workspace, &repo_slug, &name, &from, message.as_deref())
+                    .await?;
+
+                if output_json() {
+                    return print_json(&tag);
+                }
+
+                println!(
+                    "{} Created tag {} at {}",
+                    "✓".green(),
+                    tag.name.cyan(),
+                    tag.target
+                        .as_ref()
+                        .map(|t| short_hash(&t.hash))
+                        .unwrap_or_else(|| short_hash(&from))
+                );
+
+                Ok(())
+            }
+
+            TagCommands::View { repo, name } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let tag = client.get_tag(&workspace, &repo_slug, &name).await?;
+
+                if output_json() {
+                    return print_json(&tag);
+                }
+
+                println!("{}", tag.name.bold());
+                println!("{}", "─".repeat(50));
+
+                if let Some(date) = tag.date {
+                    println!(
+                        "{} {}",
+                        "Tagged:".dimmed(),
+                        date.format("%Y-%m-%d %H:%M:%S")
+                    );
+                }
+
+                if let Some(message) = &tag.message {
+                    if !message.trim().is_empty() {
+                        println!("{} {}", "Message:".dimmed(), message.trim_end());
+                    }
+                }
+
+                if let Some(target) = &tag.target {
+                    println!();
+                    println!("{} {}", "Commit:".dimmed(), target.hash);
+                    println!(
+                        "{} {}",
+                        "Author:".dimmed(),
+                        author_label(target.author.as_ref())
+                    );
+
+                    if let Some(date) = target.date {
+                        println!("{} {}", "Date:".dimmed(), date.format("%Y-%m-%d %H:%M:%S"));
+                    }
+
+                    if let Some(message) = &target.message {
+                        println!();
+                        println!("{}", message.trim_end());
+                    }
+                }
+
+                Ok(())
+            }
+
+            TagCommands::Delete { repo, name, yes } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                if !yes && !confirm_or_abort(format!("Delete tag {} from {}?", name.red(), repo))? {
+                    return Ok(());
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                client.delete_tag(&workspace, &repo_slug, &name).await?;
+
+                if output_json() {
+                    return print_json(&serde_json::json!({ "ok": true }));
+                }
+
+                println!("{} Deleted tag {}", "✓".green(), name);
+
+                Ok(())
+            }
+        }
+    }
+}

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -1,0 +1,100 @@
+use anyhow::Result;
+use clap::Subcommand;
+use tabled::{Table, Tabled};
+
+use crate::api::BitbucketClient;
+use crate::models::User;
+
+#[derive(Subcommand)]
+pub enum UserCommands {
+    /// Show the currently authenticated user
+    Whoami,
+    /// View a user's public profile
+    View {
+        /// Account ID or UUID (including braces) of the user
+        account: String,
+    },
+    /// List email addresses on the authenticated account
+    Emails,
+}
+
+#[derive(Tabled)]
+struct EmailRow {
+    #[tabled(rename = "EMAIL")]
+    email: String,
+    #[tabled(rename = "PRIMARY")]
+    primary: String,
+    #[tabled(rename = "CONFIRMED")]
+    confirmed: String,
+}
+
+/// Render a user profile as aligned key/value lines.
+fn print_user(user: &User) {
+    println!("Display name: {}", user.display_name);
+    println!("Username:     {}", user.username.as_deref().unwrap_or("-"));
+    println!(
+        "Account ID:   {}",
+        user.account_id.as_deref().unwrap_or("-")
+    );
+    println!("UUID:         {}", user.uuid);
+}
+
+/// Format an optional boolean as Yes/No, with "-" when absent.
+fn yes_no(value: Option<bool>) -> String {
+    match value {
+        Some(true) => "Yes",
+        Some(false) => "No",
+        None => "-",
+    }
+    .to_string()
+}
+
+impl UserCommands {
+    pub async fn run(self) -> Result<()> {
+        let client = BitbucketClient::from_stored().await?;
+
+        match self {
+            UserCommands::Whoami => {
+                let user = client.get_current_user().await?;
+                if super::output_json() {
+                    return super::print_json(&user);
+                }
+                print_user(&user);
+            }
+            UserCommands::View { account } => {
+                let user = client.get_user(&account).await?;
+                if super::output_json() {
+                    return super::print_json(&user);
+                }
+                print_user(&user);
+            }
+            UserCommands::Emails => {
+                let emails = client.list_user_emails().await?;
+
+                if super::output_json() {
+                    return super::print_json(&emails.values);
+                }
+
+                if emails.values.is_empty() {
+                    println!("No email addresses found");
+                    return Ok(());
+                }
+
+                let rows: Vec<EmailRow> = emails
+                    .values
+                    .iter()
+                    .map(|e| EmailRow {
+                        email: e.email.clone().unwrap_or_else(|| "-".to_string()),
+                        primary: yes_no(e.is_primary),
+                        confirmed: yes_no(e.is_confirmed),
+                    })
+                    .collect();
+
+                let table = Table::new(rows).to_string();
+                println!("{}", table);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/cli/webhook.rs
+++ b/src/cli/webhook.rs
@@ -1,0 +1,360 @@
+use anyhow::Result;
+use clap::Subcommand;
+use colored::Colorize;
+use tabled::{Table, Tabled};
+
+use super::{confirm_or_abort, output_json, parse_repo, print_json};
+use crate::api::BitbucketClient;
+use crate::models::{CreateWebhookRequest, Webhook};
+
+#[derive(Subcommand)]
+pub enum WebhookCommands {
+    /// List webhooks on a repository
+    List {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Number of results per page (max 100)
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+    },
+
+    /// Create a webhook
+    Create {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Destination URL the events are delivered to
+        #[arg(long)]
+        url: String,
+
+        /// Event key to subscribe to (repeatable, e.g. --event repo:push --event pullrequest:created)
+        #[arg(long = "event", value_name = "EVENT", required = true)]
+        events: Vec<String>,
+
+        /// Description of the webhook
+        #[arg(short, long)]
+        description: Option<String>,
+
+        /// Create the webhook in a disabled state
+        #[arg(long)]
+        inactive: bool,
+    },
+
+    /// View webhook details
+    View {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Webhook UUID (the brace-wrapped UUID shown by `webhook list`)
+        uid: String,
+    },
+
+    /// Update a webhook (unset fields keep their current values)
+    Update {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Webhook UUID (the brace-wrapped UUID shown by `webhook list`)
+        uid: String,
+
+        /// New destination URL
+        #[arg(long)]
+        url: Option<String>,
+
+        /// Replace the subscribed events (repeatable)
+        #[arg(long = "event", value_name = "EVENT")]
+        events: Vec<String>,
+
+        /// New description
+        #[arg(short, long)]
+        description: Option<String>,
+
+        /// Enable or disable the webhook
+        #[arg(long, value_name = "true|false")]
+        active: Option<bool>,
+    },
+
+    /// Delete a webhook
+    Delete {
+        /// Repository in format workspace/repo-slug
+        repo: String,
+
+        /// Webhook UUID (the brace-wrapped UUID shown by `webhook list`)
+        uid: String,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+}
+
+#[derive(Tabled)]
+struct WebhookRow {
+    #[tabled(rename = "UUID")]
+    uid: String,
+    #[tabled(rename = "URL")]
+    url: String,
+    #[tabled(rename = "ACTIVE")]
+    active: String,
+    #[tabled(rename = "EVENTS")]
+    events: String,
+}
+
+impl WebhookCommands {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            WebhookCommands::List { repo, limit } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let hooks = client
+                    .list_webhooks(&workspace, &repo_slug, Some(limit.clamp(1, 100)))
+                    .await?;
+
+                if output_json() {
+                    return print_json(&hooks.values);
+                }
+
+                if hooks.values.is_empty() {
+                    println!("No webhooks found in {}", repo);
+                    return Ok(());
+                }
+
+                let rows: Vec<WebhookRow> = hooks
+                    .values
+                    .iter()
+                    .map(|h| WebhookRow {
+                        uid: h.uuid.clone().unwrap_or_default(),
+                        url: h.url.clone(),
+                        active: if h.active.unwrap_or(false) {
+                            "Yes"
+                        } else {
+                            "No"
+                        }
+                        .to_string(),
+                        events: h.events.join(", ").chars().take(60).collect(),
+                    })
+                    .collect();
+
+                println!("{}", Table::new(rows));
+
+                if hooks.next.is_some() {
+                    println!(
+                        "\n{} More webhooks available. Use --limit to see more.",
+                        "ℹ".blue()
+                    );
+                }
+
+                Ok(())
+            }
+
+            WebhookCommands::Create {
+                repo,
+                url,
+                events,
+                description,
+                inactive,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let request = CreateWebhookRequest {
+                    description,
+                    url,
+                    active: !inactive,
+                    events,
+                };
+
+                let hook = client
+                    .create_webhook(&workspace, &repo_slug, &request)
+                    .await?;
+
+                if output_json() {
+                    return print_json(&hook);
+                }
+
+                println!(
+                    "{} Created webhook {} for {}",
+                    "✓".green(),
+                    hook.uuid.as_deref().unwrap_or("(no uid)").cyan(),
+                    hook.url
+                );
+
+                Ok(())
+            }
+
+            WebhookCommands::View { repo, uid } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+                let client = BitbucketClient::from_stored().await?;
+                let hook = client.get_webhook(&workspace, &repo_slug, &uid).await?;
+
+                if output_json() {
+                    return print_json(&hook);
+                }
+
+                println!("{}", hook.uuid.as_deref().unwrap_or(&uid).bold());
+                println!("{}", "─".repeat(50));
+
+                if let Some(desc) = &hook.description {
+                    if !desc.is_empty() {
+                        println!("{}", desc);
+                        println!();
+                    }
+                }
+
+                println!("{} {}", "URL:".dimmed(), hook.url.cyan());
+                println!(
+                    "{} {}",
+                    "Active:".dimmed(),
+                    if hook.active.unwrap_or(false) {
+                        "Yes"
+                    } else {
+                        "No"
+                    }
+                );
+
+                if hook.events.is_empty() {
+                    println!("{} (none)", "Events:".dimmed());
+                } else {
+                    println!("{}", "Events:".dimmed());
+                    for event in &hook.events {
+                        println!("  {}", event);
+                    }
+                }
+
+                Ok(())
+            }
+
+            WebhookCommands::Update {
+                repo,
+                uid,
+                url,
+                events,
+                description,
+                active,
+            } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                if url.is_none() && events.is_empty() && description.is_none() && active.is_none() {
+                    anyhow::bail!(
+                        "Nothing to update. Pass at least one option, e.g. --url or --active."
+                    );
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+
+                // PUT replaces the whole subscription, so merge the requested
+                // changes into the current state before sending.
+                let current = client.get_webhook(&workspace, &repo_slug, &uid).await?;
+                let request = build_webhook_update(current, url, events, description, active);
+
+                let updated = client
+                    .update_webhook(&workspace, &repo_slug, &uid, &request)
+                    .await?;
+
+                if output_json() {
+                    return print_json(&updated);
+                }
+
+                println!(
+                    "{} Updated webhook {}",
+                    "✓".green(),
+                    updated.uuid.as_deref().unwrap_or(&uid).cyan()
+                );
+
+                Ok(())
+            }
+
+            WebhookCommands::Delete { repo, uid, yes } => {
+                let (workspace, repo_slug) = parse_repo(&repo)?;
+
+                if !yes
+                    && !confirm_or_abort(format!("Delete webhook {} from {}?", uid.red(), repo))?
+                {
+                    return Ok(());
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                client.delete_webhook(&workspace, &repo_slug, &uid).await?;
+
+                if output_json() {
+                    return print_json(&serde_json::json!({ "ok": true }));
+                }
+
+                println!("{} Deleted webhook {}", "✓".green(), uid);
+
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Merge `webhook update` flags into the current subscription to produce the
+/// full replacement body Bitbucket's PUT expects. Unset flags keep the current
+/// values; a webhook with no recorded `active` state defaults to enabled.
+fn build_webhook_update(
+    current: Webhook,
+    url: Option<String>,
+    events: Vec<String>,
+    description: Option<String>,
+    active: Option<bool>,
+) -> CreateWebhookRequest {
+    CreateWebhookRequest {
+        description: description.or(current.description),
+        url: url.unwrap_or(current.url),
+        active: active.or(current.active).unwrap_or(true),
+        events: if events.is_empty() {
+            current.events
+        } else {
+            events
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_webhook_update;
+    use crate::models::Webhook;
+
+    fn current() -> Webhook {
+        Webhook {
+            uuid: Some("{uid}".to_string()),
+            url: "https://old.example.com/hook".to_string(),
+            description: Some("old description".to_string()),
+            active: Some(true),
+            events: vec!["repo:push".to_string()],
+        }
+    }
+
+    #[test]
+    fn build_webhook_update_keeps_current_values_when_flags_unset() {
+        let request = build_webhook_update(current(), None, Vec::new(), None, None);
+        assert_eq!(request.url, "https://old.example.com/hook");
+        assert_eq!(request.description.as_deref(), Some("old description"));
+        assert!(request.active);
+        assert_eq!(request.events, vec!["repo:push".to_string()]);
+    }
+
+    #[test]
+    fn build_webhook_update_applies_changed_fields() {
+        let request = build_webhook_update(
+            current(),
+            Some("https://new.example.com/hook".to_string()),
+            vec!["pullrequest:created".to_string()],
+            Some("new description".to_string()),
+            Some(false),
+        );
+        assert_eq!(request.url, "https://new.example.com/hook");
+        assert_eq!(request.description.as_deref(), Some("new description"));
+        assert!(!request.active);
+        assert_eq!(request.events, vec!["pullrequest:created".to_string()]);
+    }
+
+    #[test]
+    fn build_webhook_update_defaults_unknown_active_state_to_enabled() {
+        let mut hook = current();
+        hook.active = None;
+        let request = build_webhook_update(hook, None, Vec::new(), None, None);
+        assert!(request.active);
+    }
+}

--- a/src/cli/workspace.rs
+++ b/src/cli/workspace.rs
@@ -1,13 +1,176 @@
 use anyhow::Result;
 use clap::Subcommand;
+use colored::Colorize;
 use tabled::{Table, Tabled};
 
+use super::{confirm_or_abort, resolve_workspace};
 use crate::api::BitbucketClient;
+use crate::cli::pagination::{MAX_LIMIT, effective_limit};
+use crate::models::{
+    CreateProjectRequest, ProjectDetail, UpdateProjectRequest, Workspace, WorkspaceMembership,
+    WorkspacePermission,
+};
 
 #[derive(Subcommand)]
 pub enum WorkspaceCommands {
-    /// List all workspaces you have access to
-    List,
+    /// List workspaces you have access to
+    List {
+        /// Filter by your role in the workspace
+        #[arg(long, value_parser = ["member", "collaborator", "owner"])]
+        role: Option<String>,
+
+        /// Filter with a Bitbucket query (BBQL) expression, e.g. 'name~"acme"'
+        #[arg(short, long)]
+        query: Option<String>,
+
+        /// Sort by a field, e.g. 'name' or '-created_on' for descending
+        #[arg(long)]
+        sort: Option<String>,
+
+        /// Number of results per page (max 100)
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+
+        /// Fetch every page instead of a single page of results
+        #[arg(long, conflicts_with_all = ["role", "query", "sort", "limit"])]
+        all: bool,
+    },
+
+    /// View workspace details
+    View {
+        /// Workspace slug (defaults to --workspace or the configured default workspace)
+        workspace: Option<String>,
+    },
+
+    /// List members of a workspace
+    Members {
+        /// Workspace slug (defaults to --workspace or the configured default workspace)
+        workspace: Option<String>,
+
+        /// Number of results per page (max 100)
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+    },
+
+    /// List user permissions on a workspace or one of its repositories
+    Permissions {
+        /// Workspace slug (defaults to --workspace or the configured default workspace)
+        workspace: Option<String>,
+
+        /// Show permissions on this repository instead of the workspace
+        #[arg(long)]
+        repo: Option<String>,
+
+        /// Number of results per page (max 100)
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+    },
+
+    /// Manage projects in a workspace
+    Project {
+        #[command(subcommand)]
+        command: ProjectCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum ProjectCommands {
+    /// List projects in a workspace
+    List {
+        /// Workspace slug (defaults to --workspace or the configured default workspace)
+        workspace: Option<String>,
+
+        /// Filter with a Bitbucket query (BBQL) expression, e.g. 'name~"api"'
+        #[arg(short, long)]
+        query: Option<String>,
+
+        /// Sort by a field, e.g. 'name' or '-updated_on' for descending
+        #[arg(long)]
+        sort: Option<String>,
+
+        /// Number of results per page (max 100)
+        #[arg(short, long, default_value = "25")]
+        limit: u32,
+
+        /// Page number to fetch
+        #[arg(long)]
+        page: Option<u32>,
+    },
+
+    /// View project details
+    View {
+        /// Project key, e.g. PROJ
+        key: String,
+
+        /// Workspace slug (defaults to --workspace or the configured default workspace)
+        #[arg(long)]
+        workspace: Option<String>,
+    },
+
+    /// Create a new project
+    Create {
+        /// Project key, e.g. PROJ
+        key: String,
+
+        /// Project name
+        name: String,
+
+        /// Project description
+        #[arg(short, long)]
+        description: Option<String>,
+
+        /// Make the project private (default)
+        #[arg(long, conflicts_with = "public")]
+        private: bool,
+
+        /// Make the project public
+        #[arg(long)]
+        public: bool,
+
+        /// Workspace slug (defaults to --workspace or the configured default workspace)
+        #[arg(long)]
+        workspace: Option<String>,
+    },
+
+    /// Update project settings
+    Edit {
+        /// Project key, e.g. PROJ
+        key: String,
+
+        /// New project name
+        #[arg(long)]
+        name: Option<String>,
+
+        /// New description
+        #[arg(short, long)]
+        description: Option<String>,
+
+        /// Make the project private
+        #[arg(long, conflicts_with = "public")]
+        private: bool,
+
+        /// Make the project public
+        #[arg(long)]
+        public: bool,
+
+        /// Workspace slug (defaults to --workspace or the configured default workspace)
+        #[arg(long)]
+        workspace: Option<String>,
+    },
+
+    /// Delete a project
+    Delete {
+        /// Project key, e.g. PROJ
+        key: String,
+
+        /// Workspace slug (defaults to --workspace or the configured default workspace)
+        #[arg(long)]
+        workspace: Option<String>,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
 }
 
 #[derive(Tabled)]
@@ -22,41 +185,495 @@ struct WorkspaceRow {
     created: String,
 }
 
+#[derive(Tabled)]
+struct MemberRow {
+    #[tabled(rename = "NAME")]
+    name: String,
+    #[tabled(rename = "USERNAME")]
+    username: String,
+    #[tabled(rename = "UUID")]
+    uuid: String,
+}
+
+#[derive(Tabled)]
+struct PermissionRow {
+    #[tabled(rename = "USER")]
+    user: String,
+    #[tabled(rename = "PERMISSION")]
+    permission: String,
+}
+
+#[derive(Tabled)]
+struct ProjectRow {
+    #[tabled(rename = "KEY")]
+    key: String,
+    #[tabled(rename = "NAME")]
+    name: String,
+    #[tabled(rename = "PRIVATE")]
+    private: String,
+    #[tabled(rename = "UPDATED")]
+    updated: String,
+}
+
+/// Render an optional privacy flag as Yes/No/-
+fn privacy_label(is_private: Option<bool>) -> String {
+    match is_private {
+        Some(true) => "Yes",
+        Some(false) => "No",
+        None => "-",
+    }
+    .to_string()
+}
+
+fn workspace_rows(workspaces: &[Workspace]) -> Vec<WorkspaceRow> {
+    workspaces
+        .iter()
+        .map(|w| WorkspaceRow {
+            slug: w.slug.clone(),
+            name: w.name.clone(),
+            private: privacy_label(w.is_private),
+            created: w
+                .created_on
+                .map(|d| d.format("%Y-%m-%d").to_string())
+                .unwrap_or_default(),
+        })
+        .collect()
+}
+
+fn member_rows(members: &[WorkspaceMembership]) -> Vec<MemberRow> {
+    members
+        .iter()
+        .map(|m| MemberRow {
+            name: m
+                .user
+                .as_ref()
+                .map(|u| u.display_name.clone())
+                .unwrap_or_else(|| "-".to_string()),
+            username: m
+                .user
+                .as_ref()
+                .and_then(|u| u.username.clone())
+                .unwrap_or_else(|| "-".to_string()),
+            uuid: m
+                .user
+                .as_ref()
+                .map(|u| u.uuid.clone())
+                .unwrap_or_else(|| "-".to_string()),
+        })
+        .collect()
+}
+
+fn permission_rows(permissions: &[WorkspacePermission]) -> Vec<PermissionRow> {
+    permissions
+        .iter()
+        .map(|p| PermissionRow {
+            user: p
+                .user
+                .as_ref()
+                .map(|u| u.display_name.clone())
+                .unwrap_or_else(|| "-".to_string()),
+            permission: p.permission.clone().unwrap_or_else(|| "-".to_string()),
+        })
+        .collect()
+}
+
+fn project_rows(projects: &[ProjectDetail]) -> Vec<ProjectRow> {
+    projects
+        .iter()
+        .map(|p| ProjectRow {
+            key: p.key.clone(),
+            name: p.name.clone(),
+            private: privacy_label(p.is_private),
+            updated: p
+                .updated_on
+                .map(|d| d.format("%Y-%m-%d").to_string())
+                .unwrap_or_default(),
+        })
+        .collect()
+}
+
 impl WorkspaceCommands {
     pub async fn run(self) -> Result<()> {
         match self {
-            WorkspaceCommands::List => {
+            WorkspaceCommands::List {
+                role,
+                query,
+                sort,
+                limit,
+                all,
+            } => {
                 let client = BitbucketClient::from_stored().await?;
-                let workspaces = client.list_workspaces().await?;
 
-                if workspaces.is_empty() {
+                if all {
+                    let workspaces = client.list_workspaces().await?;
+
+                    if super::output_json() {
+                        return super::print_json(&workspaces);
+                    }
+
+                    if workspaces.is_empty() {
+                        println!("No workspaces found");
+                        return Ok(());
+                    }
+
+                    let table = Table::new(workspace_rows(&workspaces)).to_string();
+                    println!("{}", table);
+
+                    return Ok(());
+                }
+
+                let limit = effective_limit(limit);
+                let page = client
+                    .list_workspaces_filtered(
+                        role.as_deref(),
+                        query.as_deref(),
+                        sort.as_deref(),
+                        None,
+                        Some(limit),
+                    )
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&page.values);
+                }
+
+                if page.values.is_empty() {
                     println!("No workspaces found");
                     return Ok(());
                 }
 
-                let rows: Vec<WorkspaceRow> = workspaces
-                    .iter()
-                    .map(|w| WorkspaceRow {
-                        slug: w.slug.clone(),
-                        name: w.name.clone(),
-                        private: match w.is_private {
-                            Some(true) => "Yes",
-                            Some(false) => "No",
-                            None => "-",
-                        }
-                        .to_string(),
-                        created: w
-                            .created_on
-                            .map(|d| d.format("%Y-%m-%d").to_string())
-                            .unwrap_or_default(),
-                    })
-                    .collect();
-
-                let table = Table::new(rows).to_string();
+                let table = Table::new(workspace_rows(&page.values)).to_string();
                 println!("{}", table);
+
+                if page.next.is_some() {
+                    println!(
+                        "\n{} More workspaces available. Use --all to fetch every workspace.",
+                        "ℹ".blue()
+                    );
+                }
+
+                Ok(())
+            }
+
+            WorkspaceCommands::View { workspace } => {
+                let workspace = resolve_workspace(workspace)?;
+                let client = BitbucketClient::from_stored().await?;
+                let workspace = client.get_workspace(&workspace).await?;
+
+                if super::output_json() {
+                    return super::print_json(&workspace);
+                }
+
+                println!("{}", workspace.name.bold());
+                println!("{}", "─".repeat(50));
+                println!("{} {}", "Slug:".bold(), workspace.slug);
+                println!("{} {}", "UUID:".bold(), workspace.uuid);
+                println!(
+                    "{} {}",
+                    "Private:".bold(),
+                    privacy_label(workspace.is_private)
+                );
+                println!(
+                    "{} {}",
+                    "Created:".bold(),
+                    workspace
+                        .created_on
+                        .map(|d| d.format("%Y-%m-%d").to_string())
+                        .unwrap_or_else(|| "-".to_string())
+                );
+
+                Ok(())
+            }
+
+            WorkspaceCommands::Members { workspace, limit } => {
+                let workspace = resolve_workspace(workspace)?;
+                let limit = effective_limit(limit);
+                let client = BitbucketClient::from_stored().await?;
+                let members = client
+                    .list_workspace_members(&workspace, Some(limit))
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&members.values);
+                }
+
+                if members.values.is_empty() {
+                    println!("No members found in workspace '{}'", workspace);
+                    return Ok(());
+                }
+
+                let table = Table::new(member_rows(&members.values)).to_string();
+                println!("{}", table);
+
+                if members.next.is_some() {
+                    println!(
+                        "\n{} More members available. Increase --limit (max {}) to see more.",
+                        "ℹ".blue(),
+                        MAX_LIMIT
+                    );
+                }
+
+                Ok(())
+            }
+
+            WorkspaceCommands::Permissions {
+                workspace,
+                repo,
+                limit,
+            } => {
+                let workspace = resolve_workspace(workspace)?;
+                let limit = effective_limit(limit);
+                let client = BitbucketClient::from_stored().await?;
+                let permissions = client
+                    .list_workspace_permissions(&workspace, repo.as_deref(), None, Some(limit))
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&permissions.values);
+                }
+
+                if permissions.values.is_empty() {
+                    match &repo {
+                        Some(repo) => {
+                            println!(
+                                "No permissions found on repository '{}/{}'",
+                                workspace, repo
+                            )
+                        }
+                        None => println!("No permissions found in workspace '{}'", workspace),
+                    }
+                    return Ok(());
+                }
+
+                let table = Table::new(permission_rows(&permissions.values)).to_string();
+                println!("{}", table);
+
+                if permissions.next.is_some() {
+                    println!(
+                        "\n{} More permissions available. Increase --limit (max {}) to see more.",
+                        "ℹ".blue(),
+                        MAX_LIMIT
+                    );
+                }
+
+                Ok(())
+            }
+
+            WorkspaceCommands::Project { command } => command.run().await,
+        }
+    }
+}
+
+impl ProjectCommands {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            ProjectCommands::List {
+                workspace,
+                query,
+                sort,
+                limit,
+                page,
+            } => {
+                let workspace = resolve_workspace(workspace)?;
+                let limit = effective_limit(limit);
+                let client = BitbucketClient::from_stored().await?;
+                let projects = client
+                    .list_projects(
+                        &workspace,
+                        query.as_deref(),
+                        sort.as_deref(),
+                        page,
+                        Some(limit),
+                    )
+                    .await?;
+
+                if super::output_json() {
+                    return super::print_json(&projects.values);
+                }
+
+                if projects.values.is_empty() {
+                    println!("No projects found in workspace '{}'", workspace);
+                    return Ok(());
+                }
+
+                let table = Table::new(project_rows(&projects.values)).to_string();
+                println!("{}", table);
+
+                if projects.next.is_some() {
+                    println!(
+                        "\n{} More projects available. Use --page {} to see the next page.",
+                        "ℹ".blue(),
+                        page.unwrap_or(1) + 1
+                    );
+                }
+
+                Ok(())
+            }
+
+            ProjectCommands::View { key, workspace } => {
+                let workspace = resolve_workspace(workspace)?;
+                let client = BitbucketClient::from_stored().await?;
+                let project = client.get_project(&workspace, &key).await?;
+
+                if super::output_json() {
+                    return super::print_json(&project);
+                }
+
+                println!("{} {}", project.key.bold(), project.name);
+                println!("{}", "─".repeat(50));
+
+                if let Some(desc) = &project.description {
+                    if !desc.is_empty() {
+                        println!("{}", desc);
+                        println!();
+                    }
+                }
+
+                println!(
+                    "{} {}",
+                    "UUID:".bold(),
+                    project.uuid.as_deref().unwrap_or("-")
+                );
+                println!(
+                    "{} {}",
+                    "Private:".bold(),
+                    privacy_label(project.is_private)
+                );
+                println!(
+                    "{} {}",
+                    "Created:".bold(),
+                    project
+                        .created_on
+                        .map(|d| d.format("%Y-%m-%d").to_string())
+                        .unwrap_or_else(|| "-".to_string())
+                );
+                println!(
+                    "{} {}",
+                    "Updated:".bold(),
+                    project
+                        .updated_on
+                        .map(|d| d.format("%Y-%m-%d").to_string())
+                        .unwrap_or_else(|| "-".to_string())
+                );
+
+                Ok(())
+            }
+
+            ProjectCommands::Create {
+                key,
+                name,
+                description,
+                private: _,
+                public,
+                workspace,
+            } => {
+                let workspace = resolve_workspace(workspace)?;
+                let client = BitbucketClient::from_stored().await?;
+
+                let request = CreateProjectRequest {
+                    name,
+                    key,
+                    description,
+                    // Private unless --public was given (private is the default).
+                    is_private: Some(!public),
+                };
+
+                let project = client.create_project(&workspace, &request).await?;
+
+                if super::output_json() {
+                    return super::print_json(&project);
+                }
+
+                println!(
+                    "{} Created project {} in workspace {}",
+                    "✓".green(),
+                    project.key.cyan(),
+                    workspace
+                );
+
+                Ok(())
+            }
+
+            ProjectCommands::Edit {
+                key,
+                name,
+                description,
+                private,
+                public,
+                workspace,
+            } => {
+                let workspace = resolve_workspace(workspace)?;
+
+                let request = UpdateProjectRequest {
+                    name,
+                    description,
+                    is_private: if private {
+                        Some(true)
+                    } else if public {
+                        Some(false)
+                    } else {
+                        None
+                    },
+                };
+
+                if request.is_empty() {
+                    anyhow::bail!(
+                        "No changes specified. Pass at least one of --name, --description, --private, or --public."
+                    );
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                let project = client.update_project(&workspace, &key, &request).await?;
+
+                if super::output_json() {
+                    return super::print_json(&project);
+                }
+
+                println!("{} Updated project {}", "✓".green(), project.key.cyan());
+
+                Ok(())
+            }
+
+            ProjectCommands::Delete {
+                key,
+                workspace,
+                yes,
+            } => {
+                let workspace = resolve_workspace(workspace)?;
+
+                if !yes
+                    && !confirm_or_abort(format!(
+                        "Are you sure you want to delete project {} from workspace {}? This cannot be undone!",
+                        key.red(),
+                        workspace
+                    ))?
+                {
+                    return Ok(());
+                }
+
+                let client = BitbucketClient::from_stored().await?;
+                client.delete_project(&workspace, &key).await?;
+
+                if super::output_json() {
+                    return super::print_json(&serde_json::json!({"ok": true}));
+                }
+
+                println!("{} Deleted project {}", "✓".green(), key);
 
                 Ok(())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::privacy_label;
+
+    #[test]
+    fn privacy_label_renders_all_states() {
+        assert_eq!(privacy_label(Some(true)), "Yes");
+        assert_eq!(privacy_label(Some(false)), "No");
+        assert_eq!(privacy_label(None), "-");
     }
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -110,8 +110,6 @@ pub struct Config {
     pub auth: AuthConfig,
     #[serde(default)]
     pub defaults: DefaultsConfig,
-    #[serde(default)]
-    pub display: DisplayConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -123,22 +121,6 @@ pub struct AuthConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct DefaultsConfig {
     pub workspace: Option<String>,
-    pub repository: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DisplayConfig {
-    pub color: bool,
-    pub pager: bool,
-}
-
-impl Default for DisplayConfig {
-    fn default() -> Self {
-        Self {
-            color: true,
-            pager: true,
-        }
-    }
 }
 
 impl Config {
@@ -230,8 +212,9 @@ impl Config {
     /// Get the default workspace
     ///
     /// `[auth] default_workspace` is the primary source; `[defaults] workspace`
-    /// remains as a legacy fallback. Remove the fallback (and the
-    /// `defaults.workspace` field) in the first release after 1.0.
+    /// remains as a legacy fallback. Removing the fallback (and the
+    /// `defaults.workspace` field) is a breaking change, so it must wait for
+    /// the next major release (2.0.0).
     pub fn default_workspace(&self) -> Option<&str> {
         self.auth
             .default_workspace
@@ -255,7 +238,7 @@ mod tests {
     fn test_default_config() {
         let config = Config::default();
         assert!(config.auth.username.is_none());
-        assert!(config.display.color);
+        assert!(config.defaults.workspace.is_none());
     }
 
     #[test]
@@ -263,7 +246,7 @@ mod tests {
         let config = Config::default();
         let serialized = toml::to_string(&config).unwrap();
         let deserialized: Config = toml::from_str(&serialized).unwrap();
-        assert_eq!(config.display.color, deserialized.display.color);
+        assert_eq!(config.auth.username, deserialized.auth.username);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-// Allow dead code for API methods designed for future use
-#![allow(dead_code)]
-
 pub mod api;
 pub mod auth;
 pub mod cli;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,12 @@ use colored::Colorize;
 
 use cli::{Cli, Commands};
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     cli::set_workspace_override(cli.workspace.clone());
+    cli::set_output_format(cli.output);
 
     let result = match cli.command {
         Commands::Auth { command } => command.run().await,
@@ -19,6 +20,7 @@ async fn main() -> Result<()> {
         Commands::Issue { command } => command.run().await,
         Commands::Pipeline { command } => command.run().await,
         Commands::Workspace { command } => command.run().await,
+        Commands::User { command } => command.run().await,
         Commands::Tui => tui::run_tui(cli.workspace).await,
     };
 

--- a/src/models/commit.rs
+++ b/src/models/commit.rs
@@ -1,0 +1,179 @@
+//! Models for refs (branches and tags), commits, and source browsing.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+// The refs/commits API returns the same author shape as the pull request
+// commit payload; reuse it instead of redefining a colliding `CommitAuthor`
+// (models are glob re-exported from `crate::models`).
+use super::pr::CommitAuthor;
+
+/// A branch ref as returned by the `refs/branches` API, including its target
+/// commit. Distinct from [`super::repo::Branch`], which is the bare
+/// `{ name }` shape embedded in repository payloads.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BranchDetail {
+    pub name: String,
+    pub target: Option<CommitSummary>,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub ref_type: Option<String>,
+}
+
+/// A tag ref as returned by the `refs/tags` API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TagDetail {
+    pub name: String,
+    /// Annotation message, for annotated tags.
+    pub message: Option<String>,
+    pub target: Option<CommitSummary>,
+    /// Tag creation date, for annotated tags.
+    pub date: Option<DateTime<Utc>>,
+}
+
+/// A commit as returned by the `commits` / `commit/{hash}` endpoints and
+/// embedded as the `target` of branch and tag refs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitSummary {
+    pub hash: String,
+    pub message: Option<String>,
+    pub date: Option<DateTime<Utc>>,
+    pub author: Option<CommitAuthor>,
+}
+
+/// A file or directory entry from the `src/{ref}/{path}` listing endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SourceEntry {
+    pub path: String,
+    /// `commit_file` or `commit_directory`.
+    #[serde(rename = "type")]
+    pub entry_type: String,
+    /// File size in bytes; absent for directories.
+    pub size: Option<u64>,
+}
+
+/// One entry from the `filehistory/{ref}/{path}` endpoint: a commit that
+/// touched the file, plus the path the file had at that commit.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileHistoryEntry {
+    pub commit: Option<CommitSummary>,
+    pub path: Option<String>,
+}
+
+/// The `target` object of a ref-creation request: the commit to point at.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RefTarget {
+    pub hash: String,
+}
+
+/// Request body for `POST refs/branches`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CreateBranchRequest {
+    pub name: String,
+    pub target: RefTarget,
+}
+
+/// Request body for `POST refs/tags`. `message` is omitted from the payload
+/// when unset so Bitbucket creates a lightweight tag.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CreateTagRequest {
+    pub name: String,
+    pub target: RefTarget,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_branch_request_serializes_name_and_target_hash() {
+        let request = CreateBranchRequest {
+            name: "feature/login".to_string(),
+            target: RefTarget {
+                hash: "a1b2c3d".to_string(),
+            },
+        };
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "name": "feature/login",
+                "target": { "hash": "a1b2c3d" }
+            })
+        );
+    }
+
+    #[test]
+    fn create_tag_request_omits_unset_message() {
+        let request = CreateTagRequest {
+            name: "v1.0.0".to_string(),
+            target: RefTarget {
+                hash: "a1b2c3d".to_string(),
+            },
+            message: None,
+        };
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "name": "v1.0.0",
+                "target": { "hash": "a1b2c3d" }
+            })
+        );
+    }
+
+    #[test]
+    fn create_tag_request_includes_message_when_set() {
+        let request = CreateTagRequest {
+            name: "v1.0.0".to_string(),
+            target: RefTarget {
+                hash: "a1b2c3d".to_string(),
+            },
+            message: Some("First release".to_string()),
+        };
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["message"], serde_json::json!("First release"));
+    }
+
+    #[test]
+    fn branch_detail_maps_type_field() {
+        let branch: BranchDetail = serde_json::from_str(
+            r#"{
+                "name": "main",
+                "type": "branch",
+                "target": {
+                    "hash": "deadbeefcafe",
+                    "message": "Initial commit\n",
+                    "date": "2024-01-01T00:00:00+00:00",
+                    "author": { "raw": "Jo <jo@example.com>" }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(branch.ref_type.as_deref(), Some("branch"));
+        let target = branch.target.unwrap();
+        assert_eq!(target.hash, "deadbeefcafe");
+        assert_eq!(
+            target.author.unwrap().raw.as_deref(),
+            Some("Jo <jo@example.com>")
+        );
+    }
+
+    #[test]
+    fn source_entry_maps_type_field() {
+        let entry: SourceEntry = serde_json::from_str(
+            r#"{ "path": "src/main.rs", "type": "commit_file", "size": 1024 }"#,
+        )
+        .unwrap();
+
+        assert_eq!(entry.entry_type, "commit_file");
+        assert_eq!(entry.size, Some(1024));
+    }
+}

--- a/src/models/deploy.rs
+++ b/src/models/deploy.rs
@@ -1,0 +1,203 @@
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Deploy keys
+// ---------------------------------------------------------------------------
+
+/// An SSH deploy key granting read access to a repository.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeployKey {
+    pub id: Option<u64>,
+    /// The SSH public key material (e.g. `ssh-ed25519 AAAA... user@host`).
+    pub key: Option<String>,
+    pub label: Option<String>,
+    pub comment: Option<String>,
+}
+
+/// Request body for adding a deploy key to a repository.
+#[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
+pub struct AddDeployKeyRequest {
+    pub key: String,
+    pub label: String,
+}
+
+// ---------------------------------------------------------------------------
+// Deployment environments
+// ---------------------------------------------------------------------------
+
+/// A deployment environment (e.g. Test, Staging, Production).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Environment {
+    pub uuid: Option<String>,
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environment_type: Option<EnvironmentType>,
+}
+
+/// The category of a deployment environment: Test, Staging, or Production.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnvironmentType {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+/// Request body for creating a deployment environment.
+#[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
+pub struct CreateEnvironmentRequest {
+    pub name: String,
+    pub environment_type: EnvironmentType,
+}
+
+// ---------------------------------------------------------------------------
+// Deployments
+// ---------------------------------------------------------------------------
+
+/// A deployment of a release to an environment.
+///
+/// The Bitbucket deployments API is only loosely documented, so the nested
+/// shapes here are kept permissive (`Option` everywhere, raw JSON for the
+/// deep-nested parts).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Deployment {
+    pub uuid: Option<String>,
+    pub state: Option<DeploymentState>,
+    pub environment: Option<Environment>,
+    pub release: Option<serde_json::Value>,
+}
+
+/// The state of a deployment (e.g. UNDEPLOYED, IN_PROGRESS, COMPLETED).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeploymentState {
+    pub name: Option<String>,
+    /// Nested status object; shape varies by state, so it is kept raw.
+    pub status: Option<serde_json::Value>,
+}
+
+// ---------------------------------------------------------------------------
+// Branching model
+// ---------------------------------------------------------------------------
+
+/// A repository's effective branching model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BranchingModel {
+    pub development: Option<ModelBranch>,
+    pub production: Option<ModelBranch>,
+    pub branch_types: Option<Vec<BranchType>>,
+}
+
+/// The development or production branch in a branching model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelBranch {
+    pub name: Option<String>,
+    /// The concrete branch this resolves to (only present in the effective
+    /// model, not in the settings representation).
+    pub branch: Option<crate::models::Branch>,
+    pub use_mainbranch: Option<bool>,
+}
+
+/// A branch type prefix mapping (e.g. kind `feature` → prefix `feature/`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BranchType {
+    pub kind: Option<String>,
+    pub prefix: Option<String>,
+}
+
+/// Partial update for a repository's branching model settings. Unset fields
+/// are omitted from the request body so the corresponding settings are left
+/// untouched.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct UpdateBranchingModelRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub development: Option<BranchingModelBranchSettings>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub production: Option<BranchingModelBranchSettings>,
+}
+
+impl UpdateBranchingModelRequest {
+    pub fn is_empty(&self) -> bool {
+        self.development.is_none() && self.production.is_none()
+    }
+}
+
+/// Settings for one branch (development or production) in a branching model
+/// settings update. `enabled` only applies to the production branch.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct BranchingModelBranchSettings {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_mainbranch: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        BranchingModelBranchSettings, CreateEnvironmentRequest, EnvironmentType,
+        UpdateBranchingModelRequest,
+    };
+
+    #[test]
+    fn add_deploy_key_request_serializes_key_and_label() {
+        let request = super::AddDeployKeyRequest {
+            key: "ssh-ed25519 AAAA host".to_string(),
+            label: "deploy".to_string(),
+        };
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({ "key": "ssh-ed25519 AAAA host", "label": "deploy" })
+        );
+    }
+
+    #[test]
+    fn create_environment_request_nests_environment_type() {
+        let request = CreateEnvironmentRequest {
+            name: "prod".to_string(),
+            environment_type: EnvironmentType {
+                name: Some("Production".to_string()),
+            },
+        };
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "name": "prod",
+                "environment_type": { "name": "Production" }
+            })
+        );
+    }
+
+    #[test]
+    fn update_branching_model_request_omits_unset_fields() {
+        let request = UpdateBranchingModelRequest {
+            development: Some(BranchingModelBranchSettings {
+                name: Some("develop".to_string()),
+                use_mainbranch: Some(false),
+                enabled: None,
+            }),
+            production: None,
+        };
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "development": { "name": "develop", "use_mainbranch": false }
+            })
+        );
+    }
+
+    #[test]
+    fn update_branching_model_request_is_empty() {
+        assert!(UpdateBranchingModelRequest::default().is_empty());
+
+        let with_production = UpdateBranchingModelRequest {
+            production: Some(BranchingModelBranchSettings::default()),
+            ..Default::default()
+        };
+        assert!(!with_production.is_empty());
+    }
+}

--- a/src/models/issue.rs
+++ b/src/models/issue.rs
@@ -132,6 +132,7 @@ pub struct IssueLinks {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CreateIssueRequest {
     pub title: String,
     pub content: Option<IssueContentRequest>,
@@ -188,4 +189,34 @@ pub struct IssueCommentLinks {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateIssueCommentRequest {
     pub content: IssueContentRequest,
+}
+
+/// A single entry in an issue's change log (state transitions, reassignments,
+/// priority bumps, ...).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueChange {
+    pub id: Option<u64>,
+    pub user: Option<User>,
+    pub message: Option<IssueContent>,
+    pub created_on: Option<DateTime<Utc>>,
+    /// Map of changed field name to `{old, new}` values. Kept as raw JSON
+    /// because the API emits arbitrary field names here.
+    pub changes: Option<serde_json::Value>,
+}
+
+/// Shared shape for issue tracker metadata: components, milestones and
+/// versions all serialize as an id plus a name.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueMetaItem {
+    pub id: Option<u64>,
+    pub name: Option<String>,
+}
+
+/// A file attached to an issue.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueAttachment {
+    pub name: Option<String>,
+    /// Kept as raw JSON: the API serves `links.self.href` for attachments as
+    /// either a string or an array of strings.
+    pub links: Option<serde_json::Value>,
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,11 +1,19 @@
+pub mod commit;
+pub mod deploy;
 pub mod issue;
 pub mod pipeline;
 pub mod pr;
+pub mod project;
 pub mod repo;
 pub mod user;
+pub mod webhook;
 
+pub use commit::*;
+pub use deploy::*;
 pub use issue::*;
 pub use pipeline::*;
 pub use pr::*;
+pub use project::*;
 pub use repo::*;
 pub use user::*;
+pub use webhook::*;

--- a/src/models/pipeline.rs
+++ b/src/models/pipeline.rs
@@ -176,15 +176,26 @@ pub struct PipelineStepLinks {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TriggerPipelineRequest {
     pub target: TriggerPipelineTarget,
+    /// Pipeline variables passed to the run (secured ones are masked in logs).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variables: Option<Vec<PipelineVariableInput>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TriggerPipelineTarget {
     #[serde(rename = "type")]
     pub target_type: String,
-    pub ref_type: String,
-    pub ref_name: String,
+    /// Set for `pipeline_ref_target` targets; absent for commit targets.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ref_type: Option<String>,
+    /// Set for `pipeline_ref_target` targets; absent for commit targets.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ref_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub selector: Option<TriggerPipelineSelector>,
+    /// Set for `pipeline_commit_target` targets.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit: Option<TriggerPipelineCommit>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -194,29 +205,175 @@ pub struct TriggerPipelineSelector {
     pub pattern: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriggerPipelineCommit {
+    pub hash: String,
+    #[serde(rename = "type")]
+    pub commit_type: String,
+}
+
+/// A key/value variable supplied when triggering a pipeline.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineVariableInput {
+    pub key: String,
+    pub value: String,
+    pub secured: bool,
+}
+
 impl TriggerPipelineRequest {
+    /// Trigger a pipeline on the head of `branch`.
     pub fn for_branch(branch: &str) -> Self {
         Self {
             target: TriggerPipelineTarget {
                 target_type: "pipeline_ref_target".to_string(),
-                ref_type: "branch".to_string(),
-                ref_name: branch.to_string(),
+                ref_type: Some("branch".to_string()),
+                ref_name: Some(branch.to_string()),
                 selector: None,
+                commit: None,
             },
+            variables: None,
         }
     }
 
-    pub fn for_branch_with_pipeline(branch: &str, pipeline: &str) -> Self {
+    /// Trigger a pipeline on a specific commit hash.
+    pub fn for_commit(hash: &str) -> Self {
         Self {
             target: TriggerPipelineTarget {
-                target_type: "pipeline_ref_target".to_string(),
-                ref_type: "branch".to_string(),
-                ref_name: branch.to_string(),
-                selector: Some(TriggerPipelineSelector {
-                    selector_type: "custom".to_string(),
-                    pattern: pipeline.to_string(),
+                target_type: "pipeline_commit_target".to_string(),
+                ref_type: None,
+                ref_name: None,
+                selector: None,
+                commit: Some(TriggerPipelineCommit {
+                    hash: hash.to_string(),
+                    commit_type: "commit".to_string(),
                 }),
             },
+            variables: None,
         }
+    }
+
+    /// Select a custom pipeline (from `bitbucket-pipelines.yml`) to run.
+    pub fn with_pipeline(mut self, pipeline: &str) -> Self {
+        self.target.selector = Some(TriggerPipelineSelector {
+            selector_type: "custom".to_string(),
+            pattern: pipeline.to_string(),
+        });
+        self
+    }
+
+    /// Attach pipeline variables to the trigger request.
+    pub fn with_variables(mut self, variables: Vec<PipelineVariableInput>) -> Self {
+        self.variables = if variables.is_empty() {
+            None
+        } else {
+            Some(variables)
+        };
+        self
+    }
+}
+
+/// A pipeline variable configured on a repository or workspace.
+///
+/// Secured variables come back from the API without a `value`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineVariable {
+    pub uuid: Option<String>,
+    pub key: Option<String>,
+    pub value: Option<String>,
+    pub secured: Option<bool>,
+}
+
+/// A scheduled pipeline run configured on a repository.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineSchedule {
+    pub uuid: String,
+    pub enabled: Option<bool>,
+    pub cron_pattern: Option<String>,
+    /// Raw target object; `ref_name` inside identifies the branch.
+    pub target: Option<serde_json::Value>,
+}
+
+/// A dependency cache stored for a repository's pipelines.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineCache {
+    pub uuid: String,
+    pub name: Option<String>,
+    pub path: Option<String>,
+    pub file_size_bytes: Option<u64>,
+}
+
+/// Repository-level pipelines configuration (`pipelines_config`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelinesConfig {
+    pub enabled: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{PipelineVariableInput, TriggerPipelineRequest};
+
+    #[test]
+    fn for_branch_builds_ref_target() {
+        let req = TriggerPipelineRequest::for_branch("main");
+        assert_eq!(
+            serde_json::to_value(&req).unwrap(),
+            json!({
+                "target": {
+                    "type": "pipeline_ref_target",
+                    "ref_type": "branch",
+                    "ref_name": "main"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn for_commit_builds_commit_target_without_ref() {
+        let req = TriggerPipelineRequest::for_commit("abc123");
+        assert_eq!(
+            serde_json::to_value(&req).unwrap(),
+            json!({
+                "target": {
+                    "type": "pipeline_commit_target",
+                    "commit": {"hash": "abc123", "type": "commit"}
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn with_pipeline_adds_custom_selector() {
+        let req = TriggerPipelineRequest::for_branch("main").with_pipeline("nightly");
+        let value = serde_json::to_value(&req).unwrap();
+        assert_eq!(
+            value["target"]["selector"],
+            json!({"type": "custom", "pattern": "nightly"})
+        );
+    }
+
+    #[test]
+    fn with_variables_empty_leaves_field_absent() {
+        let req = TriggerPipelineRequest::for_branch("main").with_variables(vec![]);
+        assert!(req.variables.is_none());
+        let value = serde_json::to_value(&req).unwrap();
+        assert!(value.get("variables").is_none());
+    }
+
+    #[test]
+    fn with_variables_serializes_key_value_secured() {
+        let req = TriggerPipelineRequest::for_branch("main").with_variables(vec![
+            PipelineVariableInput {
+                key: "FOO".to_string(),
+                value: "bar".to_string(),
+                secured: true,
+            },
+        ]);
+        let value = serde_json::to_value(&req).unwrap();
+        assert_eq!(
+            value["variables"],
+            json!([{"key": "FOO", "value": "bar", "secured": true}])
+        );
     }
 }

--- a/src/models/pr.rs
+++ b/src/models/pr.rs
@@ -124,6 +124,7 @@ pub struct PullRequestLinks {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CreatePullRequestRequest {
     pub title: String,
     pub source: PullRequestBranchRef,
@@ -138,12 +139,46 @@ pub struct PullRequestBranchRef {
     pub branch: BranchInfo,
 }
 
+/// Lightweight user reference used in request bodies (e.g. reviewers).
+///
+/// Post-GDPR Bitbucket identifies users by `uuid` (or account ID) and ignores
+/// `username`, so prefer setting `uuid`. Unset fields are omitted from the
+/// serialized JSON.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserRef {
-    pub uuid: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+}
+
+/// Request body for `PUT .../pullrequests/{id}`; every field is optional and
+/// omitted from the JSON when unset, so only the provided fields change.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct UpdatePullRequestRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reviewers: Option<Vec<UserRef>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub destination: Option<PullRequestBranchRef>,
+}
+
+impl UpdatePullRequestRequest {
+    /// True when no field is set, i.e. the update would change nothing.
+    pub fn is_empty(&self) -> bool {
+        self.title.is_none()
+            && self.description.is_none()
+            && self.reviewers.is_none()
+            && self.destination.is_none()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct MergePullRequestRequest {
     #[serde(rename = "type")]
     pub merge_type: Option<String>,
@@ -193,7 +228,9 @@ pub struct CommentContent {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InlineComment {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub from: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub to: Option<u32>,
     pub path: String,
 }
@@ -208,4 +245,155 @@ pub struct CommentLinks {
     #[serde(rename = "self")]
     pub self_link: Option<Link>,
     pub html: Option<Link>,
+}
+
+/// A commit as returned by `GET .../pullrequests/{id}/commits`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrCommit {
+    pub hash: String,
+    pub message: Option<String>,
+    pub date: Option<DateTime<Utc>>,
+}
+
+/// A build/commit status as returned by `GET .../pullrequests/{id}/statuses`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitStatus {
+    pub key: Option<String>,
+    pub name: Option<String>,
+    pub state: Option<String>,
+    pub url: Option<String>,
+    pub description: Option<String>,
+}
+
+/// A per-file entry as returned by `GET .../pullrequests/{id}/diffstat`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiffStat {
+    pub status: Option<String>,
+    pub lines_added: Option<u64>,
+    pub lines_removed: Option<u64>,
+    pub old: Option<DiffStatFile>,
+    pub new: Option<DiffStatFile>,
+}
+
+/// File reference inside a [`DiffStat`] entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiffStatFile {
+    pub path: Option<String>,
+}
+
+/// A task on a pull request (`.../pullrequests/{id}/tasks`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrTask {
+    pub id: Option<u64>,
+    pub state: Option<String>,
+    pub content: Option<PrTaskContent>,
+}
+
+/// Content of a [`PrTask`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrTaskContent {
+    pub raw: Option<String>,
+}
+
+/// One entry from `GET .../pullrequests/{id}/activity`.
+///
+/// The activity feed mixes several event shapes, so each variant is kept as
+/// loose JSON; exactly one of the fields is normally populated per entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrActivity {
+    pub update: Option<serde_json::Value>,
+    pub approval: Option<serde_json::Value>,
+    pub comment: Option<serde_json::Value>,
+    pub changes_requested: Option<serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        BranchInfo, InlineComment, PullRequestBranchRef, UpdatePullRequestRequest, UserRef,
+    };
+
+    #[test]
+    fn update_request_is_empty_when_no_field_is_set() {
+        assert!(UpdatePullRequestRequest::default().is_empty());
+    }
+
+    #[test]
+    fn update_request_is_not_empty_when_any_field_is_set() {
+        let with_title = UpdatePullRequestRequest {
+            title: Some("t".into()),
+            ..Default::default()
+        };
+        let with_description = UpdatePullRequestRequest {
+            description: Some("d".into()),
+            ..Default::default()
+        };
+        let with_reviewers = UpdatePullRequestRequest {
+            reviewers: Some(vec![UserRef {
+                uuid: None,
+                username: Some("alice".into()),
+            }]),
+            ..Default::default()
+        };
+        let with_destination = UpdatePullRequestRequest {
+            destination: Some(PullRequestBranchRef {
+                branch: BranchInfo {
+                    name: "main".into(),
+                },
+            }),
+            ..Default::default()
+        };
+
+        assert!(!with_title.is_empty());
+        assert!(!with_description.is_empty());
+        assert!(!with_reviewers.is_empty());
+        assert!(!with_destination.is_empty());
+    }
+
+    #[test]
+    fn update_request_serializes_only_set_fields() {
+        let request = UpdatePullRequestRequest {
+            title: Some("New title".into()),
+            destination: Some(PullRequestBranchRef {
+                branch: BranchInfo {
+                    name: "develop".into(),
+                },
+            }),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "title": "New title",
+                "destination": { "branch": { "name": "develop" } }
+            })
+        );
+    }
+
+    #[test]
+    fn inline_comment_omits_from_when_none() {
+        let inline = InlineComment {
+            from: None,
+            to: Some(3),
+            path: "src/main.rs".into(),
+        };
+
+        let json = serde_json::to_value(&inline).unwrap();
+        assert_eq!(json, serde_json::json!({ "to": 3, "path": "src/main.rs" }));
+        assert!(json.get("from").is_none());
+    }
+
+    #[test]
+    fn user_ref_with_only_uuid_omits_username() {
+        let user = UserRef {
+            uuid: Some("{account-uuid}".into()),
+            username: None,
+        };
+
+        let json = serde_json::to_value(&user).unwrap();
+        assert_eq!(json, serde_json::json!({ "uuid": "{account-uuid}" }));
+        assert!(json.get("username").is_none());
+    }
 }

--- a/src/models/project.rs
+++ b/src/models/project.rs
@@ -1,0 +1,139 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::user::{User, Workspace};
+
+/// A Bitbucket project as returned by the workspace projects endpoints.
+///
+/// Named `ProjectDetail` to avoid colliding with the lightweight
+/// [`Project`](super::repo::Project) reference embedded in repositories.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectDetail {
+    pub uuid: Option<String>,
+    pub key: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub is_private: Option<bool>,
+    pub created_on: Option<DateTime<Utc>>,
+    pub updated_on: Option<DateTime<Utc>>,
+}
+
+/// Body for creating a new project in a workspace.
+#[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
+pub struct CreateProjectRequest {
+    pub name: String,
+    pub key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_private: Option<bool>,
+}
+
+/// Partial update for an existing project. Unset fields are omitted from the
+/// request body so the corresponding settings are left untouched.
+#[derive(Debug, Clone, Default, Serialize)]
+#[non_exhaustive]
+pub struct UpdateProjectRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_private: Option<bool>,
+}
+
+impl UpdateProjectRequest {
+    /// True when no field is set, i.e. the update would be a no-op.
+    pub fn is_empty(&self) -> bool {
+        self.name.is_none() && self.description.is_none() && self.is_private.is_none()
+    }
+}
+
+/// A user's membership in a workspace, as returned by
+/// `GET /workspaces/{workspace}/members`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceMembership {
+    pub user: Option<User>,
+    pub workspace: Option<Workspace>,
+}
+
+/// A permission grant on a workspace (or one of its repositories), as
+/// returned by `GET /workspaces/{workspace}/permissions`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspacePermission {
+    pub user: Option<User>,
+    pub permission: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CreateProjectRequest, ProjectDetail, UpdateProjectRequest};
+
+    #[test]
+    fn project_detail_deserializes_with_minimal_fields() {
+        let payload = r#"{ "key": "PROJ", "name": "My Project" }"#;
+        let project: ProjectDetail = serde_json::from_str(payload).unwrap();
+        assert_eq!(project.key, "PROJ");
+        assert_eq!(project.name, "My Project");
+        assert!(project.uuid.is_none());
+        assert!(project.is_private.is_none());
+    }
+
+    #[test]
+    fn create_request_omits_unset_options() {
+        let request = CreateProjectRequest {
+            name: "My Project".to_string(),
+            key: "PROJ".to_string(),
+            description: None,
+            is_private: Some(true),
+        };
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({ "name": "My Project", "key": "PROJ", "is_private": true })
+        );
+    }
+
+    #[test]
+    fn update_request_omits_unset_fields() {
+        let request = UpdateProjectRequest {
+            description: Some("new description".to_string()),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({ "description": "new description" })
+        );
+    }
+
+    #[test]
+    fn update_request_is_empty() {
+        assert!(UpdateProjectRequest::default().is_empty());
+
+        assert!(
+            !UpdateProjectRequest {
+                name: Some("Renamed".to_string()),
+                ..Default::default()
+            }
+            .is_empty()
+        );
+        assert!(
+            !UpdateProjectRequest {
+                description: Some(String::new()),
+                ..Default::default()
+            }
+            .is_empty()
+        );
+        assert!(
+            !UpdateProjectRequest {
+                is_private: Some(false),
+                ..Default::default()
+            }
+            .is_empty()
+        );
+    }
+}

--- a/src/models/repo.rs
+++ b/src/models/repo.rs
@@ -85,6 +85,7 @@ pub struct ProjectLinks {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CreateRepositoryRequest {
     pub scm: String,
     pub name: Option<String>,
@@ -95,6 +96,10 @@ pub struct CreateRepositoryRequest {
     pub language: Option<String>,
     pub has_issues: Option<bool>,
     pub has_wiki: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub website: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mainbranch: Option<Branch>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -105,6 +110,7 @@ pub struct ProjectKey {
 /// Partial update for an existing repository. Unset fields are omitted from
 /// the request body so the corresponding settings are left untouched.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct UpdateRepositoryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -121,6 +127,8 @@ pub struct UpdateRepositoryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub has_wiki: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub website: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub project: Option<ProjectKey>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mainbranch: Option<Branch>,
@@ -135,6 +143,7 @@ impl UpdateRepositoryRequest {
             && self.fork_policy.is_none()
             && self.has_issues.is_none()
             && self.has_wiki.is_none()
+            && self.website.is_none()
             && self.project.is_none()
             && self.mainbranch.is_none()
     }
@@ -152,6 +161,8 @@ impl Default for CreateRepositoryRequest {
             language: None,
             has_issues: Some(true),
             has_wiki: Some(false),
+            website: None,
+            mainbranch: None,
         }
     }
 }
@@ -202,5 +213,21 @@ mod tests {
             ..Default::default()
         };
         assert!(!with_project.is_empty());
+    }
+
+    #[test]
+    fn update_request_website_counts_as_non_empty_and_serializes() {
+        let request = UpdateRepositoryRequest {
+            website: Some("https://example.com".to_string()),
+            ..Default::default()
+        };
+
+        assert!(!request.is_empty());
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({ "website": "https://example.com" })
+        );
     }
 }

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -14,9 +14,18 @@ pub struct User {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserLinks {
+    #[serde(rename = "self")]
     pub self_link: Option<Link>,
     pub html: Option<Link>,
     pub avatar: Option<Link>,
+}
+
+/// An email address associated with the authenticated user.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserEmail {
+    pub email: Option<String>,
+    pub is_primary: Option<bool>,
+    pub is_confirmed: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/models/webhook.rs
+++ b/src/models/webhook.rs
@@ -1,0 +1,117 @@
+use serde::{Deserialize, Serialize};
+
+use super::user::User;
+
+/// A repository webhook subscription.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Webhook {
+    /// Server-assigned identifier, a UUID wrapped in braces (e.g. `{1a2b-...}`).
+    pub uuid: Option<String>,
+    /// Destination URL the events are delivered to.
+    pub url: String,
+    pub description: Option<String>,
+    pub active: Option<bool>,
+    /// Event keys this hook subscribes to (e.g. `repo:push`).
+    #[serde(default)]
+    pub events: Vec<String>,
+}
+
+/// Body for creating (POST) or replacing (PUT) a webhook subscription.
+///
+/// Bitbucket's PUT replaces the whole subscription, so updates send a full
+/// body built by merging the current hook with the changed fields.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CreateWebhookRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub url: String,
+    pub active: bool,
+    pub events: Vec<String>,
+}
+
+/// A branch restriction rule on a repository.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BranchRestriction {
+    pub id: Option<u64>,
+    /// Rule kind (e.g. `push`, `force`, `delete`, `require_approvals_to_merge`).
+    pub kind: String,
+    /// Branch pattern the rule applies to (glob, e.g. `main` or `release/*`).
+    pub pattern: Option<String>,
+    /// How `pattern` is interpreted (`glob` or `branching_model`).
+    pub branch_match_kind: Option<String>,
+    /// Numeric parameter for kinds that need one (e.g. required approval count).
+    pub value: Option<u64>,
+    /// Users exempt from the rule (for kinds like `push`).
+    pub users: Option<Vec<User>>,
+}
+
+/// A user's explicit permission on a repository.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserPermission {
+    pub user: Option<User>,
+    /// Permission level: `read`, `write`, or `admin`.
+    pub permission: String,
+}
+
+/// A group's explicit permission on a repository.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroupPermission {
+    pub group: Option<GroupRef>,
+    /// Permission level: `read`, `write`, or `admin`.
+    pub permission: String,
+}
+
+/// Minimal reference to a workspace group as embedded in permission entries.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroupRef {
+    pub name: Option<String>,
+    pub slug: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CreateWebhookRequest, Webhook};
+
+    #[test]
+    fn create_webhook_request_omits_unset_description() {
+        let request = CreateWebhookRequest {
+            description: None,
+            url: "https://example.com/hook".to_string(),
+            active: true,
+            events: vec!["repo:push".to_string()],
+        };
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "url": "https://example.com/hook",
+                "active": true,
+                "events": ["repo:push"],
+            })
+        );
+    }
+
+    #[test]
+    fn create_webhook_request_includes_description_when_set() {
+        let request = CreateWebhookRequest {
+            description: Some("CI trigger".to_string()),
+            url: "https://example.com/hook".to_string(),
+            active: false,
+            events: vec![],
+        };
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["description"], "CI trigger");
+        assert_eq!(json["active"], false);
+    }
+
+    #[test]
+    fn webhook_deserializes_without_events() {
+        let webhook: Webhook =
+            serde_json::from_str(r#"{ "url": "https://example.com/hook" }"#).unwrap();
+        assert!(webhook.events.is_empty());
+        assert_eq!(webhook.uuid, None);
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -76,11 +76,6 @@ impl App {
         self.status = Some(message.to_string());
     }
 
-    /// Clear status message
-    pub fn clear_status(&mut self) {
-        self.status = None;
-    }
-
     /// Set error message
     pub fn set_error(&mut self, message: &str) {
         self.error = Some(message.to_string());
@@ -419,15 +414,6 @@ impl App {
         } else {
             self.set_error("No workspace configured");
         }
-        Ok(())
-    }
-
-    /// Load all data
-    pub async fn load_all_data(&mut self) -> Result<()> {
-        self.load_repositories().await?;
-        self.load_pull_requests().await?;
-        self.load_issues().await?;
-        self.load_pipelines().await?;
         Ok(())
     }
 }

--- a/src/tui/views/mod.rs
+++ b/src/tui/views/mod.rs
@@ -13,8 +13,6 @@ pub enum View {
 pub struct ViewState {
     /// Currently selected index
     pub selected_index: usize,
-    /// Scroll offset
-    pub scroll_offset: usize,
 }
 
 impl ViewState {
@@ -30,11 +28,5 @@ impl ViewState {
         if max > 0 && self.selected_index < max - 1 {
             self.selected_index += 1;
         }
-    }
-
-    /// Reset selection
-    pub fn reset(&mut self) {
-        self.selected_index = 0;
-        self.scroll_offset = 0;
     }
 }


### PR DESCRIPTION
## Summary

Expands the CLI to cover the Bitbucket Cloud REST API v2.0 surface and marks the **1.0.0 stability release**. Adds ~70 subcommands across new groups plus a global `--output json` flag, then hardens the whole result through audit → code-review → simplify → optimize passes.

**New surface** (full list in CHANGELOG.md):
- **repo**: `branch`, `tag`, `commit`, `file`, `webhook`, `branch-restriction`, `reviewer`, `permission`, `deploy-key`, `environment`, `deployment`, `branching-model`, `watchers`, `forks`, `download get`, list/create filter flags
- **pr**: `edit`, `unapprove`, `request-changes`, `unrequest-changes`, `commits`, `statuses`, `diffstat`, `activity`, `patch`, `task` group, comment lifecycle, `--reviewers`, inline/threaded comments
- **issue**: `edit`, `delete`, `comments`, vote/watch, `changes`, tracker metadata, `attachment` group, filtered list
- **pipeline**: trigger vars/commit, filtered list, step selection, `variable`/`workspace-variable`/`schedule`/`cache`/`config`/`rerun`
- **workspace**: `view`, `members`, `permissions`, `project` group — **user**: `whoami`, `view`, `emails`
- Global `--output <table|json>` on every command

**Hardening highlights:** pub API frozen for 1.0 (`#[non_exhaustive]`, `pub(crate)` internals, dead items removed); shared pagination + URL-encoding helpers; gzip; download-to-`Bytes`; error-context on resolve-then-act flows; secured-variable JSON masking; BBQL quoting; `docs/SMOKE-TESTS.md` tracking endpoints pending live verification.

## Breaking changes

See CHANGELOG.md 1.0.0: `list_issue_comments`/`update_pull_request` signatures, `UserRef` reshape, removed dead pub items, `[display]`/`[defaults.repository]` config keys, and pre-1.0 command/flag renames (`issue attachment` group, `pr unrequest-changes`, `repo tag --from`, `repo commit --ref`).

## Test plan

- `cargo test` **222 passed**, `cargo clippy --all-targets` **0 warnings**, **0 suppressions**, `cargo fmt` clean
- Docs site `ng build` clean; renamed commands smoke-tested
- Endpoints in `docs/SMOKE-TESTS.md` need one live run before trusting the mutating write paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)