### PR TITLE
chore: rebrand from Pegasus Heavy Industries to quinnjr

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,14 @@
 # Default owners for everything in the repo
-* @pegasusheavy/maintainers
+* @quinnjr
 
 # Rust code
-/src/ @pegasusheavy/maintainers
-/Cargo.toml @pegasusheavy/maintainers
-/Cargo.lock @pegasusheavy/maintainers
+/src/ @quinnjr
+/Cargo.toml @quinnjr
+/Cargo.lock @quinnjr
 
 # Documentation
-/docs/ @pegasusheavy/maintainers
-*.md @pegasusheavy/maintainers
+/docs/ @quinnjr
+*.md @quinnjr
 
 # CI/CD
-/.github/ @pegasusheavy/maintainers
+/.github/ @quinnjr

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-patreon: PegasusHeavyIndustries
+custom: https://quinnjr.dev

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A powerful command-line interface for Bitbucket Cloud - manage repos, PRs, issues, and pipelines from your terminal with OAuth 2.0"
-authors = ["Pegasus Heavy Industries"]
+authors = ["quinnjr"]
 license = "MIT"
 repository = "https://github.com/quinnjr/bitbucket-cli"
 homepage = "https://github.com/quinnjr/bitbucket-cli"
@@ -96,8 +96,8 @@ codegen-units = 1
 
 # Debian package configuration
 [package.metadata.deb]
-maintainer = "Pegasus Heavy Industries"
-copyright = "2025, Pegasus Heavy Industries <contact@pegasusheavy.com>"
+maintainer = "quinnjr"
+copyright = "2025-2026, Joseph Quinn <quinn.josephr@proton.me>"
 license-file = ["LICENSE", "4"]
 extended-description = """\
 A powerful command-line interface for Bitbucket Cloud. \

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Pegasus Heavy Industries
-Copyright (c) 2026 Joseph Quinn
+Copyright (c) 2025-2026 Joseph Quinn
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ If you find this project useful, please consider:
 - ⭐ Starring the repository
 - 🐛 Reporting bugs
 - 💡 Suggesting features
-- 💰 [Supporting on Patreon](https://www.patreon.com/c/PegasusHeavyIndustries)
+- 💰 [Supporting the project](https://quinnjr.dev)
 
 ---
 
-Made with ❤️ by [Pegasus Heavy Industries](https://github.com/pegasusheavy)
+Made with ❤️ by [quinnjr](https://quinnjr.dev)

--- a/packaging/alpine/APKBUILD
+++ b/packaging/alpine/APKBUILD
@@ -1,5 +1,5 @@
-# Contributor: Pegasus Heavy Industries
-# Maintainer: Pegasus Heavy Industries
+# Contributor: quinnjr
+# Maintainer: quinnjr
 pkgname=bitbucket-cli
 pkgver=1.0.0
 pkgrel=0

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: Pegasus Heavy Industries
+# Maintainer: quinnjr
 pkgname=bitbucket-cli
 pkgver=1.0.0
 pkgrel=1

--- a/packaging/windows/main.wxs
+++ b/packaging/windows/main.wxs
@@ -4,7 +4,7 @@
 
     <Package
         Name="Bitbucket CLI"
-        Manufacturer="Pegasus Heavy Industries"
+        Manufacturer="quinnjr"
         Version="1.0.0"
         UpgradeCode="12345678-1234-1234-1234-123456789012"
         Scope="perMachine"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -23,7 +23,7 @@ use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(name = "bitbucket")]
-#[command(author = "Pegasus Heavy Industries")]
+#[command(author = "quinnjr")]
 #[command(version)]
 #[command(about = "A command-line interface for Bitbucket Cloud", long_about = None)]
 #[command(propagate_version = true)]


### PR DESCRIPTION
## Summary

Replaces all remaining **Pegasus Heavy Industries** branding with **quinnjr** and points brand links at **https://quinnjr.dev**. Copyright is attributed to **Joseph Quinn**.

## Identity split

- **`quinnjr`** — maintainer/author handle: Cargo `authors`, clap `author`, deb `maintainer`, APKBUILD/PKGBUILD maintainer comments, WiX `Manufacturer`, CODEOWNERS.
- **Joseph Quinn `<quinn.josephr@proton.me>`** — legal copyright holder: `LICENSE` (`Copyright (c) 2025-2026 Joseph Quinn`) and the deb `copyright` field.
- **https://quinnjr.dev** — brand links: README support line + footer attribution, and the `FUNDING.yml` sponsor button.

## Notes

- `LICENSE` previously carried two copyright lines (Pegasus Heavy Industries + Joseph Quinn); consolidated to a single Joseph Quinn holder.
- `CODEOWNERS` used org-team syntax `@pegasusheavy/maintainers`; since `quinnjr` is a **user** account, that's now `@quinnjr` (the valid form for a user-owned repo).
- `FUNDING.yml` switched from `patreon:` to `custom: https://quinnjr.dev` (the old Patreon was Pegasus-specific).

## Verification

- `0` remaining `pegasus` references in any tracked file.
- `cargo test`: **222 passed**. `cargo metadata` validates. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)